### PR TITLE
make PFCP Session-Delete-Request idempotent

### DIFF
--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -1212,7 +1212,8 @@ void sgwc_sxa_handle_session_deletion_response(
     }
 
     if (pfcp_rsp->cause.presence) {
-        if (pfcp_rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
+        if (pfcp_rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED &&
+            pfcp_rsp->cause.u8 != OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND) {
             ogs_warn("PFCP Cause[%d] : Not Accepted", pfcp_rsp->cause.u8);
             cause_value = gtp_cause_from_pfcp(pfcp_rsp->cause.u8);
         }

--- a/src/sgwu/pfcp-sm.c
+++ b/src/sgwu/pfcp-sm.c
@@ -218,6 +218,14 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
                 sess, xact, &message->pfcp_session_modification_request);
             break;
         case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
+            if (!sess) {
+                uint64_t seid = message->h.seid_presence ? message->h.seid : 0;
+                ogs_warn("Session Deletion Request: No Context");
+                ogs_pfcp_send_error_message(xact, seid,
+                        OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
+                        OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
+                break;
+            }
             sgwu_sxa_handle_session_deletion_request(
                 sess, xact, &message->pfcp_session_deletion_request);
             break;

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -379,14 +379,6 @@ void sgwu_sxa_handle_session_deletion_request(
 
     ogs_debug("Session Deletion Request");
 
-    if (!sess) {
-        ogs_warn("Session Deletion Request: No Context");
-        ogs_pfcp_send_error_message(xact, 0,
-                OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
-                OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
-        return;
-    }
-
     ogs_assert(sess);
 
     sgwu_pfcp_send_session_deletion_response(xact, sess);

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -380,7 +380,7 @@ void sgwu_sxa_handle_session_deletion_request(
     ogs_debug("Session Deletion Request");
 
     if (!sess) {
-        ogs_error("No Context");
+        ogs_warn("Session Deletion Request: No Context");
         ogs_pfcp_send_error_message(xact, 0,
                 OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -630,7 +630,8 @@ int smf_5gc_n4_handle_session_deletion_response(
     }
 
     if (rsp->cause.presence) {
-        if (rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
+        if (rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED &&
+            rsp->cause.u8 != OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND) {
             ogs_warn("PFCP Cause [%d] : Not Accepted", rsp->cause.u8);
             status = sbi_status_from_pfcp(rsp->cause.u8);
         }
@@ -1061,7 +1062,8 @@ uint8_t smf_epc_n4_handle_session_deletion_response(
         ogs_error("No Cause");
         return OGS_PFCP_CAUSE_MANDATORY_IE_MISSING;
     }
-    if (rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
+    if (rsp->cause.u8 != OGS_PFCP_CAUSE_REQUEST_ACCEPTED &&
+        rsp->cause.u8 != OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND) {
             ogs_warn("PFCP Cause[%d] : Not Accepted", rsp->cause.u8);
             return rsp->cause.u8;
     }

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -447,7 +447,7 @@ void upf_n4_handle_session_deletion_request(
     ogs_debug("Session Deletion Request");
 
     if (!sess) {
-        ogs_error("No Context");
+        ogs_warn("Session Deletion Request: No Context");
         ogs_pfcp_send_error_message(xact, 0,
                 OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
                 OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -446,14 +446,6 @@ void upf_n4_handle_session_deletion_request(
 
     ogs_debug("Session Deletion Request");
 
-    if (!sess) {
-        ogs_warn("Session Deletion Request: No Context");
-        ogs_pfcp_send_error_message(xact, 0,
-                OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
-                OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
-        return;
-    }
-
     ogs_assert(sess);
 
     upf_pfcp_send_session_deletion_response(xact, sess);

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -223,6 +223,14 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
                 sess, xact, &message->pfcp_session_modification_request);
             break;
         case OGS_PFCP_SESSION_DELETION_REQUEST_TYPE:
+            if (!sess) {
+                uint64_t seid = message->h.seid_presence ? message->h.seid : 0;
+                ogs_warn("Session Deletion Request: No Context");
+                ogs_pfcp_send_error_message(xact, seid,
+                        OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE,
+                        OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND, 0);
+                break;
+            }
             upf_n4_handle_session_deletion_request(
                 sess, xact, &message->pfcp_session_deletion_request);
             break;


### PR DESCRIPTION
Straightforward PR that makes PFCP more idempotent with respect to session deletions.

Right now, if the SMF (or SGWC) sends a Session-Deletion-Request for a session that the UPF (or SGWU) already does not have, the UPF will return an error (OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND). The SMF will ignore this error message and continue to send Session-Deletion-Request messages and potentially GTPv2 error messages depending on the exact codepath. As a side-note, this situation (being out of sync) can happen if the UPF crashes or intermittently loses connectivity with the SMF.

With this PR, the UPF returns the same error message and log entries, but the SMF handles this particular error (session not found) the same way as if the request had succeeded, since the state is the same either way. This allows everything else to proceed as normal. I thought this approach was the best way to keep the error noted in the logs and pcap but still recover into a clean working state, since both sides are already there