### PR TITLE
increase the bitsize of the "num" field that indexes TACs for a given TAI

### DIFF
--- a/lib/nas/5gs/types.h
+++ b/lib/nas/5gs/types.h
@@ -272,7 +272,7 @@ typedef struct ogs_5gs_tai0_list_s {
     struct {
     ED3(uint8_t spare:1;,
         uint8_t type:2;,
-        uint8_t num:5;)
+        uint16_t num:16;)
         /*
          * Do not change 'ogs_plmn_id_t' to 'ogs_nas_plmn_id_t'.
          * Use 'ogs_plmn_id_t' for easy implementation.
@@ -287,7 +287,7 @@ typedef struct ogs_5gs_tai0_list_s {
 typedef struct ogs_5gs_tai2_list_s {
 ED3(uint8_t spare:1;,
     uint8_t type:2;,
-    uint8_t num:5;)
+    uint16_t num:16;)
     /*
      * Do not change 'ogs_5gs_tai_t' to 'ogs_nas_tracking_area_identity_t'.
      * Use 'ogs_5gs_tai_t' for easy implementation.

--- a/lib/nas/eps/types.h
+++ b/lib/nas/eps/types.h
@@ -521,7 +521,7 @@ typedef struct ogs_eps_tai0_list_s {
     struct {
     ED3(uint8_t spare:1;,
         uint8_t type:2;,
-        uint8_t num:5;)
+        uint16_t num:16;)
         /*
          * Do not change 'ogs_plmn_id_t' to 'ogs_nas_plmn_id_t'.
          * Use 'ogs_plmn_id_t' for easy implementation.
@@ -536,7 +536,7 @@ typedef struct ogs_eps_tai0_list_s {
 typedef struct ogs_eps_tai2_list_s {
 ED3(uint8_t spare:1;,
     uint8_t type:2;,
-    uint8_t num:5;)
+    uint16_t num:16;)
     /*
      * Do not change 'ogs_eps_tai_t' to 'ogs_nas_tracking_area_identity_t'.
      * Use 'ogs_eps_tai_t' for easy implementation.


### PR DESCRIPTION
In commit 6cd832199d5c2619c9b295d148b01a6164091680 we increased the max number of TAIs (defined in macro OGS_MAX_NUM_OF_TAI) from 16 to 256. However, the "num" field used to search/lookup/index the number of TACs for a given TAI is only 5bits long, and therefore overflows (with very unhelpful error-messages) if you have n > 32 TACs no matter what the value of OGS_MAX_NUM_OF_TAI is.

For our purposes 8 bits would suffice, but the true solution is choosing a value large enough that sizeof(num) will always be < OGS_MAX_NUM_OF_TAI. I am using uint16_t because the TAC field itself is only 16 bits, so we should never see more than 2^16 different TACs for a given PLMN.