### PR TITLE
[pfcp] make user-plane pfcp nodes stateless

### DIFF
--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -89,6 +89,8 @@ bool ogs_pfcp_cp_handle_association_setup_request(
                 OGS_ADDR(addr, buf), OGS_PORT(addr));
     }
 
+    ogs_pfcp_cp_send_session_set_deletion_request(node, NULL);
+
     return true;
 }
 
@@ -134,6 +136,8 @@ bool ogs_pfcp_cp_handle_association_setup_response(
         ogs_warn("F-TEID allocation/release not supported with peer [%s]:%d",
                 OGS_ADDR(addr, buf), OGS_PORT(addr));
     }
+
+    ogs_pfcp_cp_send_session_set_deletion_request(node, NULL);
 
     return true;
 }

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -128,11 +128,20 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             OGS_FSM_TRAN(s, sgwc_pfcp_state_associated);
+
+            sgwc_sess_t *ps;
+            ogs_list_for_each(&node->sess_list, ps) {
+                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
+            }
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             OGS_FSM_TRAN(s, sgwc_pfcp_state_associated);
+
+            ogs_list_for_each(&node->sess_list, ps) {
+                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
+            }
             break;
         default:
             ogs_warn("cannot handle PFCP message type[%d]",
@@ -201,11 +210,20 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             ogs_warn("PFCP[REQ] has already been associated");
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
+
+            sgwc_sess_t *ps;
+            ogs_list_for_each(&node->sess_list, ps) {
+                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
+            }
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_warn("PFCP[RSP] has already been associated");
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
+
+            ogs_list_for_each(&node->sess_list, ps) {
+                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
+            }
             break;
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
             if (!message->h.seid_presence) {

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -130,11 +130,20 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e)
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
             OGS_FSM_TRAN(s, smf_pfcp_state_associated);
+
+            smf_sess_t *ps;
+            ogs_list_for_each(&node->sess_list, ps) {
+                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
+            }
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             OGS_FSM_TRAN(s, smf_pfcp_state_associated);
+
+            ogs_list_for_each(&node->sess_list, ps) {
+                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
+            }
             break;
         default:
             ogs_warn("cannot handle PFCP message type[%d]",
@@ -205,11 +214,20 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             ogs_warn("PFCP[REQ] has already been associated");
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
+
+            smf_sess_t *ps;
+            ogs_list_for_each(&node->sess_list, ps) {
+                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
+            }
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_warn("PFCP[RSP] has already been associated");
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
+
+            ogs_list_for_each(&node->sess_list, ps) {
+                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
+            }
             break;
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
             if (!message->h.seid_presence)


### PR DESCRIPTION
This PR adds some unorthodox-yet-still-3gpp-compliant behavior to PFCP. The context for this PR is that in our deployment model, the user plane PFCP components (sgw-u and upf) are located on a separate machine from the control plane components (sgw-c and smf). As such, the code needs to be hardened against intermittent connectivity and/or message drops, but also against the complete failure of one or more components. The modifications in this PR address a number of out-of-sync situations we've seen in the wild, and explicitly make the assumption that the cloud CPS entities "control" the UPS entities, and are therefore authoritatively correct. The changes to the code are as follows:

- Previous PRs ensured that individual PFCP operations (add, update, remove) are idempotent from the direction of the CPS to the UPS.
- Any time the PFCP nodes associate or re-associate, the control side sends a session-set-delete-request message to the user side. This message effectively tells the user side to erase any session information it currently has.
- After the session-set-delete-request message, the control side sends a session-add message for every session it wants the user side to establish.

In testing and practice, I've found this approach to be incredibly resilient. If the control and user sides lose connectivity, the user-side keeps every active session alive so service isn't interrupted. Upon reconnection, the sessions are established almost instantly with minimal packet loss. If either of the user side components crash, they come back up online and almost instantly regain all their state when they reattach. I've stress tested the user-side somewhat extensively and am very pleased with these results.