### PR TITLE
[core] fix timer overflow on 32bit systems

### DIFF
--- a/lib/core/ogs-time.c
+++ b/lib/core/ogs-time.c
@@ -242,7 +242,7 @@ ogs_time_t ogs_get_monotonic_time(void)
 #if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return ((ts.tv_sec * 1000000UL) + (ts.tv_nsec / 1000UL));
+    return (((int64_t) ts.tv_sec * 1000000UL) + (ts.tv_nsec / 1000UL));
 #elif defined(__APPLE__)
     static mach_timebase_info_data_t info = {0};
     static double ratio = 0.0;


### PR DESCRIPTION
the open5gs time structure (ogs_time_t) is a 64bit int that counts in microseconds. The ogs_get_monotonic_time() function receives a system-specific timestruct (measured in seconds and nanoseconds) and converts to 64bit microseconds. On 32bit systems, the line `ts.tv_sec * 1000000UL` will do the math as 32bits before casting the whole number to 64bits; this 
 effectively creates an overflow that deadlocks the system every 71minutes. The solution is to explicitly cast `ts.tv_sec` to 64bits before the math.