### PR TITLE
Need to make smf_sess_remove idempotent

### DIFF
--- a/lib/core/ogs-pool.h
+++ b/lib/core/ogs-pool.h
@@ -114,9 +114,18 @@ typedef unsigned int ogs_index_t;
     if (((pool)->size != (pool)->avail)) \
         ogs_error("%d in '%s[%d]' were not released.", \
                 (pool)->size - (pool)->avail, (pool)->name, (pool)->size); \
-    ogs_free((pool)->free); \
-    ogs_free((pool)->array); \
-    ogs_free((pool)->index); \
+    if ((pool)->free) {\
+    	ogs_free((pool)->free); \
+	(pool)->free = NULL; \
+    } \
+    if ((pool)->array) {\
+        ogs_free((pool)->array); \
+	(pool)->array = NULL; \
+    } \
+    if ((pool)->index) {\
+        ogs_free((pool)->index); \
+	(pool)->index = NULL; \
+    } \
 } while (0)
 
 #ifdef __cplusplus

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1597,8 +1597,10 @@ void smf_sess_remove(smf_sess_t *sess)
     if (sess->policy_association_id)
         ogs_free(sess->policy_association_id);
 
-    if (sess->session.name)
+    if (sess->session.name) {
         ogs_free(sess->session.name);
+	sess->session.name = NULL;
+    }
 
     if (sess->upf_n3_addr)
         ogs_freeaddrinfo(sess->upf_n3_addr);
@@ -1618,8 +1620,9 @@ void smf_sess_remove(smf_sess_t *sess)
 
     smf_bearer_remove_all(sess);
 
-    ogs_assert(sess->pfcp.bar);
-    ogs_pfcp_bar_delete(sess->pfcp.bar);
+    if (sess->pfcp.bar) {
+        ogs_pfcp_bar_delete(sess->pfcp.bar);
+    }
 
     smf_sess_delete_cp_up_data_forwarding(sess);
 


### PR DESCRIPTION
`smf_sess_remove` usually should not be called more than once for a given smf_sess_t structure, but in some obscure codepaths (due to sessions added/removed via different APNs) it is intentionally called again on a smf_sess_t. In these cases the code currently segfaults due to double-frees that are addressed in this PR.