### PR TITLE
Need to make sgwc_sess_remove idempotent

### DIFF
--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -407,13 +407,16 @@ int sgwc_sess_remove(sgwc_sess_t *sess)
 
     sgwc_bearer_remove_all(sess);
 
-    ogs_assert(sess->pfcp.bar);
-    ogs_pfcp_bar_delete(sess->pfcp.bar);
+    if (sess->pfcp.bar) {
+        ogs_pfcp_bar_delete(sess->pfcp.bar);        
+    }
 
     ogs_pfcp_pool_final(&sess->pfcp);
 
-    ogs_assert(sess->session.name);
-    ogs_free(sess->session.name);
+    if (sess->session.name) {
+        ogs_free(sess->session.name);
+        sess->session.name = NULL;
+    }
 
     ogs_pool_free(&sgwc_sess_pool, sess);
 


### PR DESCRIPTION
Problem context is similar to #18 but for sgwc instead of smf. Again, it is *very* unlikely that this codepath gets called twice for the same sgwc_sess_t, but the code does acknowledge that it can happen. Either way, by checking for double-frees we effectively make this operation idempotent, which is always a plus.