### PR TITLE
[sgwc] need check for sess before calling sgwc_sxa_handle_session_deletion_response

### DIFF
--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -265,6 +265,11 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
                     sess = sgwc_sess_find_by_seid(be64toh(sent_hdr->seid));
             }
 
+	    if (!sess) {
+		ogs_warn("No session associated with Session Deletion Response");
+		break;
+	    }
+
             sgwc_sxa_handle_session_deletion_response(
                 sess, xact, e->gtp_message,
                 &message->pfcp_session_deletion_response);


### PR DESCRIPTION
Part of idempotent session_delete means we changed the plumbing into sgwc_sxa_handle_session_deletion_response to handle cases where there's no sess, or we find it a different way (based of of xact). It follows that for other error messages, sess might not exist, so we need to avoid a segfault.