### PR TITLE
increase num_served_tais

### DIFF
--- a/lib/core/ogs-3gpp-types.h
+++ b/lib/core/ogs-3gpp-types.h
@@ -79,7 +79,7 @@ extern "C" {
 #define OGS_MAX_PCO_LEN                 251
 #define OGS_MAX_FQDN_LEN                256
 
-#define OGS_MAX_NUM_OF_SERVED_TAI       16
+#define OGS_MAX_NUM_OF_SERVED_TAI       256
 #define OGS_MAX_NUM_OF_ALGORITHM        8
 
 #define OGS_MAX_NUM_OF_BPLMN            6


### PR DESCRIPTION
previously (in #3, 6cd832199d5c2619c9b295d148b01a6164091680) we increased OGS_MAX_NUM_OF_TAI from 16 to 256 to correspond with our architecture. This was a mistake, since OGS_MAX_NUM_OF_TAI is actually a protocol-enforced limit used to encode s1ap request/response pairs. The correct variable to increase was OGS_MAX_NUM_OF_SERVED_TAI instead.