### PR TITLE
remove mongodb install from osx script

### DIFF
--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -6,11 +6,6 @@ jobs:
     name: Build and Test on MacOS Latest
     runs-on: macos-latest
     steps:
-    - name: Install MongoDB with Package Manager
-      run: |
-          brew tap mongodb/brew
-          brew install mongodb-community
-          brew services start mongodb-community
     - name: Create the TUN device with the interface name `ogstun`.
       run: |
           sudo ifconfig lo0 alias 127.0.0.2 netmask 255.255.255.255


### PR DESCRIPTION
It is unclear why exactly this is the case, but mongodb installation recently started failing for the osx build in this meson CI script. Removing this line (which has already been done upstream in open5gs/open5gs:7231daf) fixes the issue and gets the OSX build/tests to succeed.