### PR TITLE
need to remove pfcp->sess_list

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -652,7 +652,6 @@ ogs_pfcp_node_t *ogs_pfcp_node_new(ogs_sockaddr_t *sa_list)
     ogs_list_init(&node->local_list);
     ogs_list_init(&node->remote_list);
 
-    ogs_list_init(&node->sess_list);
     ogs_list_init(&node->gtpu_resource_list);
 
     return node;

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -77,7 +77,6 @@ typedef struct ogs_pfcp_context_s {
         ogs_assert((__cTX)); \
         ogs_assert((__pNODE)); \
         (__cTX)->pfcp_node = __pNODE; \
-        ogs_list_add(&(__pNODE)->sess_list, (__cTX)); \
     } while(0)
 
 typedef struct ogs_pfcp_node_s {
@@ -109,7 +108,6 @@ typedef struct ogs_pfcp_node_s {
     /* flag to enable/ disable full list RR for this node */
     uint8_t         rr_enable;
 
-    ogs_list_t      sess_list;
     ogs_list_t      gtpu_resource_list; /* User Plane IP Resource Information */
 
     ogs_pfcp_up_function_features_t up_function_features;

--- a/lib/pfcp/handler.c
+++ b/lib/pfcp/handler.c
@@ -89,8 +89,6 @@ bool ogs_pfcp_cp_handle_association_setup_request(
                 OGS_ADDR(addr, buf), OGS_PORT(addr));
     }
 
-    ogs_pfcp_cp_send_session_set_deletion_request(node, NULL);
-
     return true;
 }
 
@@ -136,8 +134,6 @@ bool ogs_pfcp_cp_handle_association_setup_response(
         ogs_warn("F-TEID allocation/release not supported with peer [%s]:%d",
                 OGS_ADDR(addr, buf), OGS_PORT(addr));
     }
-
-    ogs_pfcp_cp_send_session_set_deletion_request(node, NULL);
 
     return true;
 }

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -394,16 +394,12 @@ void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
 int sgwc_sess_remove(sgwc_sess_t *sess)
 {
     sgwc_ue_t *sgwc_ue = NULL;
-    ogs_pfcp_node_t *node = NULL;
 
     ogs_assert(sess);
     sgwc_ue = sess->sgwc_ue;
     ogs_assert(sgwc_ue);
-    node = sess->pfcp_node;
-    ogs_assert(node);
 
     ogs_list_remove(&sgwc_ue->sess_list, sess);
-    ogs_list_remove(&node->sess_list, sess);
 
     sgwc_bearer_remove_all(sess);
 

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -263,6 +263,23 @@ int sgwc_pfcp_send_session_establishment_request(
     return rv;
 }
 
+int sgwc_pfcp_resend_established_sessions(ogs_pfcp_node_t *node)
+{
+    sgwc_ue_t *sgwc_ue = NULL;
+    sgwc_sess_t *sess = NULL;
+
+    ogs_pfcp_cp_send_session_set_deletion_request(node, NULL);
+
+    ogs_list_for_each(&sgwc_self()->sgw_ue_list, sgwc_ue) {
+        ogs_list_for_each(&sgwc_ue->sess_list, sess) {
+            if (sess->pfcp_node == node) {
+                sgwc_pfcp_send_session_establishment_request(sess, NULL, NULL);                
+            }
+        }
+    }
+    return OGS_OK;
+}
+
 int sgwc_pfcp_send_session_modification_request(
         sgwc_sess_t *sess, ogs_gtp_xact_t *gtp_xact,
         ogs_pkbuf_t *gtpbuf, uint64_t flags)

--- a/src/sgwc/pfcp-path.h
+++ b/src/sgwc/pfcp-path.h
@@ -34,6 +34,7 @@ int sgwc_pfcp_send_bearer_to_modify_list(
 
 int sgwc_pfcp_send_session_establishment_request(
         sgwc_sess_t *sess, ogs_gtp_xact_t *gtp_xact, ogs_pkbuf_t *gtpbuf);
+int sgwc_pfcp_resend_established_sessions(ogs_pfcp_node_t *node);
 
 int sgwc_pfcp_send_session_modification_request(
         sgwc_sess_t *sess, ogs_gtp_xact_t *gtp_xact,

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -129,19 +129,16 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e)
                     &message->pfcp_association_setup_request);
             OGS_FSM_TRAN(s, sgwc_pfcp_state_associated);
 
-            sgwc_sess_t *ps;
-            ogs_list_for_each(&node->sess_list, ps) {
-                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
-            }
+            sgwc_pfcp_resend_established_sessions(node);
+
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             OGS_FSM_TRAN(s, sgwc_pfcp_state_associated);
 
-            ogs_list_for_each(&node->sess_list, ps) {
-                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
-            }
+            sgwc_pfcp_resend_established_sessions(node);
+
             break;
         default:
             ogs_warn("cannot handle PFCP message type[%d]",
@@ -211,19 +208,16 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
 
-            sgwc_sess_t *ps;
-            ogs_list_for_each(&node->sess_list, ps) {
-                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
-            }
+            sgwc_pfcp_resend_established_sessions(node);
+
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_warn("PFCP[RSP] has already been associated");
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
 
-            ogs_list_for_each(&node->sess_list, ps) {
-                sgwc_pfcp_send_session_establishment_request(ps, NULL, NULL);
-            }
+            sgwc_pfcp_resend_established_sessions(node);
+            
             break;
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
             if (!message->h.seid_presence) {

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -170,7 +170,6 @@ int sgwu_sess_remove(sgwu_sess_t *sess)
     ogs_assert(sess);
 
     ogs_list_remove(&self.sess_list, sess);
-    ogs_list_remove(&sess->pfcp_node->sess_list, sess);
     ogs_pfcp_sess_clear(&sess->pfcp);
 
     ogs_hash_set(self.seid_hash, &sess->sgwc_sxa_f_seid.seid,

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -405,8 +405,10 @@ void sgwu_sxa_handle_session_set_deletion_request(
 
     ogs_debug("Session Set Deletion Request");
 
-    ogs_list_for_each_safe(&node->sess_list, next, sess) {
-        sgwu_sess_remove(sess);
+    ogs_list_for_each_safe(&sgwu_self()->sess_list, next, sess) {
+        if (sess->pfcp_node == node) {
+            sgwu_sess_remove(sess);            
+        }
     }
 
     ogs_pfcp_up_send_session_set_deletion_response(xact, OGS_PFCP_CAUSE_REQUEST_ACCEPTED);

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1531,7 +1531,6 @@ void smf_sess_remove(smf_sess_t *sess)
 {
     int i;
     smf_ue_t *smf_ue = NULL;
-    ogs_pfcp_node_t *node = NULL;
     smf_event_t e;
 
     char buf1[OGS_ADDRSTRLEN];
@@ -1540,8 +1539,6 @@ void smf_sess_remove(smf_sess_t *sess)
     ogs_assert(sess);
     smf_ue = sess->smf_ue;
     ogs_assert(smf_ue);
-    node = sess->pfcp_node;
-    ogs_assert(node);
 
     ogs_info("Removed Session: UE IMSI:[%s] DNN:[%s:%d] IPv4:[%s] IPv6:[%s]",
             smf_ue->supi ? smf_ue->supi : smf_ue->imsi_bcd,
@@ -1550,7 +1547,6 @@ void smf_sess_remove(smf_sess_t *sess)
             sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
 
     ogs_list_remove(&smf_ue->sess_list, sess);
-    ogs_list_remove(&node->sess_list, sess);
 
     memset(&e, 0, sizeof(e));
     e.sess = sess;

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -460,6 +460,23 @@ int smf_epc_pfcp_send_session_establishment_request(
     return rv;
 }
 
+int smf_epc_pfcp_resend_established_sessions(ogs_pfcp_node_t *node)
+{
+    smf_ue_t *smf_ue = NULL;
+    smf_sess_t *sess = NULL;
+
+    ogs_pfcp_cp_send_session_set_deletion_request(node, NULL);
+
+    ogs_list_for_each(&smf_self()->smf_ue_list, smf_ue) {
+        ogs_list_for_each(&smf_ue->sess_list, sess) {
+            if (sess->pfcp_node == node) {
+                smf_epc_pfcp_send_session_establishment_request(sess, NULL);
+            }
+        }
+    }
+    return OGS_OK;    
+}
+
 int smf_epc_pfcp_send_all_pdr_modification_request(
         smf_sess_t *sess, void *gtp_xact, ogs_pkbuf_t *gtpbuf,
         uint64_t flags, uint8_t gtp_pti, uint8_t gtp_cause)

--- a/src/smf/pfcp-path.h
+++ b/src/smf/pfcp-path.h
@@ -48,6 +48,7 @@ int smf_5gc_pfcp_send_session_deletion_request(
 
 int smf_epc_pfcp_send_session_establishment_request(
         smf_sess_t *sess, void *gtp_xact);
+int smf_epc_pfcp_resend_established_sessions(ogs_pfcp_node_t *node);
 int smf_epc_pfcp_send_all_pdr_modification_request(
         smf_sess_t *sess, void *gtp_xact, ogs_pkbuf_t *gtpbuf,
         uint64_t flags, uint8_t gtp_pti, uint8_t gtp_cause);

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -131,19 +131,16 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e)
                     &message->pfcp_association_setup_request);
             OGS_FSM_TRAN(s, smf_pfcp_state_associated);
 
-            smf_sess_t *ps;
-            ogs_list_for_each(&node->sess_list, ps) {
-                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
-            }
+            smf_epc_pfcp_resend_established_sessions(node);
+
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
             OGS_FSM_TRAN(s, smf_pfcp_state_associated);
 
-            ogs_list_for_each(&node->sess_list, ps) {
-                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
-            }
+            smf_epc_pfcp_resend_established_sessions(node);
+
             break;
         default:
             ogs_warn("cannot handle PFCP message type[%d]",
@@ -215,19 +212,16 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
             ogs_pfcp_cp_handle_association_setup_request(node, xact,
                     &message->pfcp_association_setup_request);
 
-            smf_sess_t *ps;
-            ogs_list_for_each(&node->sess_list, ps) {
-                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
-            }
+            smf_epc_pfcp_resend_established_sessions(node);
+
             break;
         case OGS_PFCP_ASSOCIATION_SETUP_RESPONSE_TYPE:
             ogs_warn("PFCP[RSP] has already been associated");
             ogs_pfcp_cp_handle_association_setup_response(node, xact,
                     &message->pfcp_association_setup_response);
 
-            ogs_list_for_each(&node->sess_list, ps) {
-                smf_epc_pfcp_send_session_establishment_request(ps, NULL);
-            }
+            smf_epc_pfcp_resend_established_sessions(node);
+
             break;
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
             if (!message->h.seid_presence)

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -187,7 +187,6 @@ int upf_sess_remove(upf_sess_t *sess)
     upf_sess_urr_acc_remove_all(sess);
 
     ogs_list_remove(&self.sess_list, sess);
-    ogs_list_remove(&sess->pfcp_node->sess_list, sess);
     ogs_pfcp_sess_clear(&sess->pfcp);
 
     ogs_hash_set(self.seid_hash, &sess->smf_n4_f_seid.seid,

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -472,8 +472,10 @@ void upf_n4_handle_session_set_deletion_request(
 
     ogs_debug("Session Set Deletion Request");
 
-    ogs_list_for_each_safe(&node->sess_list, next, sess) {
-        upf_sess_remove(sess);
+    ogs_list_for_each_safe(&upf_self()->sess_list, next, sess) {
+        if (sess->pfcp_node == node) {
+            upf_sess_remove(sess);
+        }
     }
 
     ogs_pfcp_up_send_session_set_deletion_response(xact, OGS_PFCP_CAUSE_REQUEST_ACCEPTED);


### PR DESCRIPTION
cf47336 (#11) introduced some complicated and major regressions due to a fundamental misunderstanding of the role of ogs_list structure. The goal of the previous PRs was to keep track of the current pfcp sessions each pfcp node has, so that they can easily be re-established after a PFCP disconnection (main logic: after a crash, send session-set-delete to the node followed by session-establishment-request for each active session).

However, ogs_list is also used for memory management, so an entity (i.e. pfcp_sess_t) can only belong to one list at any given time, and as previously written, pfcp_sess_t was "owned" by its corresponding ue_t. Hence, cf47336 caused a wide range of undefined behavior by adding the same node to multiple lists upon establishment, and freeing it from all lists upon release.

This PR leaves the structural memory-management code as-is, and removes the pfcp sess_list structure/operations. When it needs to lookup the set of PFCP sessions associated to a given pfcp node (i.e. after sending session-set-delete), it accomplishes the same goal by simply iterating through the entire list of every pfcp_sess_t and comparing pfcp_node to the node in question.