### PR TITLE
stats functions are creating segfaults/crashes

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1839,7 +1839,7 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
 
     char buffer[20];
     sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
-    ogs_write_file_value("num_enbs", buffer);
+    ogs_write_file_value("mme/num_enbs", buffer);
 
     return enb;
 }
@@ -1878,7 +1878,7 @@ int mme_enb_remove(mme_enb_t *enb)
 
     char buffer[20];
     sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
-    ogs_write_file_value("num_enbs", buffer);
+    ogs_write_file_value("mme/num_enbs", buffer);
 
     return OGS_OK;
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3499,7 +3499,7 @@ static void stats_add_enb_ue(enb_ue_t *enb_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_enb_ue);
     ogs_write_file_value("mme/num_ues", buffer);
-    ogs_add_line_file("mme/list_ues", enb_ue->mme_ue->imsi_bcd);
+//    ogs_add_line_file("mme/list_ues", enb_ue->mme_ue->imsi_bcd);
 }
 
 static void stats_remove_enb_ue(enb_ue_t *enb_ue)
@@ -3510,7 +3510,7 @@ static void stats_remove_enb_ue(enb_ue_t *enb_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_enb_ue);
     ogs_write_file_value("mme/num_ues", buffer);
-    ogs_remove_line_file("mme/list_ues", enb_ue->mme_ue->imsi_bcd);
+//    ogs_remove_line_file("mme/list_ues", enb_ue->mme_ue->imsi_bcd);
 }
 
 static void stats_add_mme_session(mme_sess_t *sess)
@@ -3525,12 +3525,12 @@ static void stats_add_mme_session(mme_sess_t *sess)
     sprintf(buffer, "%d\n", num_of_mme_sess);
     ogs_write_file_value("mme/num_sessions", buffer);
 
-    sprintf(buffer, "imsi:%s apn:%s ip4:%s ip6:%s\n",
-        sess->mme_ue->imsi_bcd,
-        sess->session->name,
-        sess->session->ue_ip.ipv4 ? OGS_INET_NTOP(sess->session->ue_ip.addr, buf1) : "",
-        sess->session->ue_ip.ipv6 ? OGS_INET6_NTOP(sess->session->ue_ip.addr6, buf2) : "");
-    ogs_add_line_file("mme/list_sessions", buffer);
+//    sprintf(buffer, "imsi:%s apn:%s ip4:%s ip6:%s\n",
+//        sess->mme_ue->imsi_bcd,
+//        sess->session->name,
+//        sess->session->ue_ip.ipv4 ? OGS_INET_NTOP(sess->session->ue_ip.addr, buf1) : "",
+//        sess->session->ue_ip.ipv6 ? OGS_INET6_NTOP(sess->session->ue_ip.addr6, buf2) : "");
+//    ogs_add_line_file("mme/list_sessions", buffer);
 }
 
 static void stats_remove_mme_session(mme_sess_t *sess)
@@ -3545,10 +3545,10 @@ static void stats_remove_mme_session(mme_sess_t *sess)
     sprintf(buffer, "%d\n", num_of_mme_sess);
     ogs_write_file_value("mme/num_sessions", buffer);
 
-    sprintf(buffer, "imsi:%s apn:%s ip4:%s ip6:%s\n",
-        sess->mme_ue->imsi_bcd,
-        sess->session->name,
-        sess->session->ue_ip.ipv4 ? OGS_INET_NTOP(sess->session->ue_ip.addr, buf1) : "",
-        sess->session->ue_ip.ipv6 ? OGS_INET6_NTOP(sess->session->ue_ip.addr6, buf2) : "");
-    ogs_remove_line_file("mme/list_sessions", buffer);
+//    sprintf(buffer, "imsi:%s apn:%s ip4:%s ip6:%s\n",
+//        sess->mme_ue->imsi_bcd,
+//        sess->session->name,
+//        sess->session->ue_ip.ipv4 ? OGS_INET_NTOP(sess->session->ue_ip.addr, buf1) : "",
+//        sess->session->ue_ip.ipv6 ? OGS_INET6_NTOP(sess->session->ue_ip.addr6, buf2) : "");
+//    ogs_remove_line_file("mme/list_sessions", buffer);
 }

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -270,7 +270,7 @@ uint8_t smf_s5c_handle_create_session_request(
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
-    stats_add_smf_session_info(sess);
+//    stats_add_smf_session_info(sess);
 
     /* Remove all previous bearer */
     smf_bearer_remove_all(sess);


### PR DESCRIPTION
Each and every line of code in this PR induces at least one test-failure or crash. Some fixes are obvious (e.g. "num_enbs" file needs "mme/" in front of it) but others are not quite clear yet. Commenting them out for now to get us to a stable/working dev branch; will investigate and push fixes when we have more time.