### PR TITLE
Improve stats-tracking for CPS

### DIFF
--- a/lib/core/ogs-log.c
+++ b/lib/core/ogs-log.c
@@ -204,32 +204,6 @@ void ogs_write_file_subdir(const char *filename) {
 
     return;
 }
-
-void ogs_add_line_file(const char *filename, const char *value) {
-// grep -qx "$VALUE" $FILENAME || echo "$VALUE" >> $FILENAME
-
-    char filestring[50];
-    strcpy(filestring, BASEFILE);
-    strcat(filestring, "/");
-    strcat(filestring, filename);
-
-    char cmd[256];
-    sprintf(cmd, "grep -qx \"%s\" %s || echo \"%s\" >> %s\n", value, filestring, value, filestring);
-    system(cmd);
-}
-
-void ogs_remove_line_file(const char *filename, const char *value) {
-// sed -i '/$VALUE/d' $FILENAME
-
-    char filestring[50];
-    strcpy(filestring, BASEFILE);
-    strcat(filestring, "/");
-    strcat(filestring, filename);
-
-    char cmd[256];
-    sprintf(cmd, "sed -i '/%s/d' %s\n", value, filestring);
-    system(cmd);
-}
 // END SPENCERS FILE-LOG SYSTEM
 
 ogs_log_t *ogs_log_add_stderr(void)

--- a/lib/core/ogs-log.h
+++ b/lib/core/ogs-log.h
@@ -75,9 +75,6 @@ void ogs_log_cycle(void);
 void ogs_write_file_value(const char *filename, const char *value);
 void ogs_write_file_start(const char *filename);
 void ogs_write_file_subdir(const char *filename);
-
-void ogs_add_line_file(const char *filename, const char *value);
-void ogs_remove_line_file(const char *filename, const char *value);
 // END SPENCERS FILE-LOG SYSTEM
 
 ogs_log_t *ogs_log_add_stderr(void);

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -143,6 +143,8 @@ int esm_handle_pdn_connectivity_request(mme_bearer_t *bearer,
         return OGS_ERROR;
     }
 
+    stats_write_list_sessions();
+
     return OGS_OK;
 }
 
@@ -223,6 +225,8 @@ int esm_handle_information_response(mme_sess_t *sess,
                 OGS_GTP_CREATE_IN_ATTACH_REQUEST));
         return OGS_ERROR;
     }
+
+    stats_write_list_sessions();
 
     return OGS_OK;
 }

--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -143,7 +143,7 @@ int esm_handle_pdn_connectivity_request(mme_bearer_t *bearer,
         return OGS_ERROR;
     }
 
-    stats_write_list_sessions();
+    stats_write_list_mme_sessions();
 
     return OGS_OK;
 }
@@ -226,7 +226,7 @@ int esm_handle_information_response(mme_sess_t *sess,
         return OGS_ERROR;
     }
 
-    stats_write_list_sessions();
+    stats_write_list_mme_sessions();
 
     return OGS_OK;
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1843,6 +1843,7 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     char buffer[20];
     sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
     ogs_write_file_value("mme/num_enbs", buffer);
+    stats_write_list_enbs();
 
     return enb;
 }
@@ -1882,6 +1883,7 @@ int mme_enb_remove(mme_enb_t *enb)
     char buffer[20];
     sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
     ogs_write_file_value("mme/num_enbs", buffer);
+    stats_write_list_enbs();
 
     return OGS_OK;
 }
@@ -3498,6 +3500,23 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     }
 
     return 0;
+}
+
+void stats_write_list_enbs(void) {
+    mme_enb_t *enb = NULL;
+
+    char buf[OGS_ADDRSTRLEN];
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+
+    ogs_list_for_each(&self.enb_list, enb) {
+        ptr += sprintf(ptr, "ip:%s\n", OGS_ADDR(enb->sctp.addr, buf));
+    }
+
+    ogs_write_file_value("mme/list_enbs", buffer);
+    ogs_free(buffer);
 }
 
 void stats_write_list_ues(void) {

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1843,7 +1843,7 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     char buffer[20];
     sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
     ogs_write_file_value("mme/num_enbs", buffer);
-    stats_write_list_enbs();
+    stats_write_list_mme_enbs();
 
     return enb;
 }
@@ -1883,7 +1883,7 @@ int mme_enb_remove(mme_enb_t *enb)
     char buffer[20];
     sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
     ogs_write_file_value("mme/num_enbs", buffer);
-    stats_write_list_enbs();
+    stats_write_list_mme_enbs();
 
     return OGS_OK;
 }
@@ -2682,7 +2682,7 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
 
     ogs_hash_set(self.imsi_ue_hash, mme_ue->imsi, mme_ue->imsi_len, mme_ue);
 
-    stats_write_list_ues();
+    stats_write_list_mme_ues();
 
     return OGS_OK;
 }
@@ -3502,7 +3502,7 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     return 0;
 }
 
-void stats_write_list_enbs(void) {
+void stats_write_list_mme_enbs(void) {
     mme_enb_t *enb = NULL;
 
     char buf[OGS_ADDRSTRLEN];
@@ -3525,7 +3525,7 @@ void stats_write_list_enbs(void) {
     ogs_free(buffer);
 }
 
-void stats_write_list_ues(void) {
+void stats_write_list_mme_ues(void) {
     mme_ue_t *mme_ue = NULL;
     char *buffer = NULL;
     char *ptr = NULL;
@@ -3543,7 +3543,7 @@ void stats_write_list_ues(void) {
 #define MAX_APN 63
 #define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
 
-void stats_write_list_sessions(void) {
+void stats_write_list_mme_sessions(void) {
     mme_ue_t *mme_ue = NULL;
     mme_sess_t *sess = NULL;
     ogs_session_t *session = NULL;
@@ -3593,7 +3593,7 @@ static void stats_add_mme_ue(mme_ue_t *enb_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_mme_ue);
     ogs_write_file_value("mme/num_ues", buffer);
-    stats_write_list_ues();
+    stats_write_list_mme_ues();
 }
 
 static void stats_remove_mme_ue(mme_ue_t *enb_ue)
@@ -3603,7 +3603,7 @@ static void stats_remove_mme_ue(mme_ue_t *enb_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_mme_ue);
     ogs_write_file_value("mme/num_ues", buffer);
-    stats_write_list_ues();
+    stats_write_list_mme_ues();
 }
 
 static void stats_add_mme_session(mme_sess_t *sess)
@@ -3616,7 +3616,7 @@ static void stats_add_mme_session(mme_sess_t *sess)
     sprintf(buffer, "%d\n", num_of_mme_sess);
     ogs_write_file_value("mme/num_sessions", buffer);
 
-    stats_write_list_sessions();
+    stats_write_list_mme_sessions();
 }
 
 static void stats_remove_mme_session(mme_sess_t *sess)
@@ -3629,5 +3629,5 @@ static void stats_remove_mme_session(mme_sess_t *sess)
     sprintf(buffer, "%d\n", num_of_mme_sess);
     ogs_write_file_value("mme/num_sessions", buffer);
 
-    stats_write_list_sessions();
+    stats_write_list_mme_sessions();
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -61,8 +61,6 @@ static void stats_add_mme_ue(mme_ue_t *mme_ue);
 static void stats_remove_mme_ue(mme_ue_t *mme_ue);
 static void stats_add_mme_session(mme_sess_t *sess);
 static void stats_remove_mme_session(mme_sess_t *sess);
-static void stats_write_list_ues(void);
-static void stats_write_list_sessions(void);
 
 static bool compare_ue_info(mme_sgw_t *node, enb_ue_t *enb_ue);
 static mme_sgw_t *selected_sgw_node(mme_sgw_t *current, enb_ue_t *enb_ue);
@@ -2682,6 +2680,8 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
 
     ogs_hash_set(self.imsi_ue_hash, mme_ue->imsi, mme_ue->imsi_len, mme_ue);
 
+    stats_write_list_ues();
+
     return OGS_OK;
 }
 
@@ -3500,7 +3500,7 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     return 0;
 }
 
-static void stats_write_list_ues(void) {
+void stats_write_list_ues(void) {
     mme_ue_t *mme_ue = NULL;
     char *buffer = NULL;
     char *ptr = NULL;
@@ -3518,7 +3518,7 @@ static void stats_write_list_ues(void) {
 #define MAX_APN 63
 #define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
 
-static void stats_write_list_sessions(void) {
+void stats_write_list_sessions(void) {
     mme_ue_t *mme_ue = NULL;
     mme_sess_t *sess = NULL;
     ogs_session_t *session = NULL;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3508,11 +3508,17 @@ void stats_write_list_enbs(void) {
     char buf[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
+    int i = 0;
 
     ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
 
     ogs_list_for_each(&self.enb_list, enb) {
-        ptr += sprintf(ptr, "ip:%s\n", OGS_ADDR(enb->sctp.addr, buf));
+        ptr += sprintf(ptr, "ip:%s tac:%u",
+            OGS_ADDR(enb->sctp.addr, buf),enb->supported_ta_list[0].tac);
+        for(i = 1; i < enb->num_of_supported_ta_list; i++) {
+            ptr += sprintf(ptr, ",%u",enb->supported_ta_list[i].tac);
+        }
+        ptr += sprintf(ptr, "\n");
     }
 
     ogs_write_file_value("mme/list_enbs", buffer);

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -871,9 +871,9 @@ void mme_ebi_pool_clear(mme_ue_t *mme_ue);
 uint8_t mme_selected_int_algorithm(mme_ue_t *mme_ue);
 uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue);
 
-void stats_write_list_enbs(void);
-void stats_write_list_ues(void);
-void stats_write_list_sessions(void);
+void stats_write_list_mme_enbs(void);
+void stats_write_list_mme_ues(void);
+void stats_write_list_mme_sessions(void);
 
 #ifdef __cplusplus
 }

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -871,6 +871,7 @@ void mme_ebi_pool_clear(mme_ue_t *mme_ue);
 uint8_t mme_selected_int_algorithm(mme_ue_t *mme_ue);
 uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue);
 
+void stats_write_list_enbs(void);
 void stats_write_list_ues(void);
 void stats_write_list_sessions(void);
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -871,6 +871,9 @@ void mme_ebi_pool_clear(mme_ue_t *mme_ue);
 uint8_t mme_selected_int_algorithm(mme_ue_t *mme_ue);
 uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue);
 
+void stats_write_list_ues(void);
+void stats_write_list_sessions(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -84,10 +84,10 @@ int mme_initialize()
     ogs_write_file_value("mme/num_ues", buffer);
     ogs_write_file_value("mme/num_sessions", buffer);
 
-    sprintf(buffer, "List of Active Sessions\n");    
-    ogs_write_file_value("mme/list_sessions", buffer);
-    sprintf(buffer, "List of Attached UEs\n");
+    sprintf(buffer, "\n");    
+    ogs_write_file_value("mme/list_enbs", buffer);
     ogs_write_file_value("mme/list_ues", buffer);
+    ogs_write_file_value("mme/list_sessions", buffer);
 
     return OGS_OK;
 }

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -191,8 +191,8 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         else
             enb->max_num_of_ostreams = max_num_of_ostreams;
 
-        ogs_info("eNB-N2[%s] max_num_of_ostreams : %d",
-            OGS_ADDR(enb->sctp.addr, buf), enb->max_num_of_ostreams);
+        ogs_info("eNB-N2[%s] tac: %u max_num_of_ostreams : %d",
+            OGS_ADDR(enb->sctp.addr, buf), enb->supported_ta_list[0].tac, enb->max_num_of_ostreams);
 
         break;
 

--- a/src/mme/mme-sm.c
+++ b/src/mme/mme-sm.c
@@ -191,8 +191,8 @@ void mme_state_operational(ogs_fsm_t *s, mme_event_t *e)
         else
             enb->max_num_of_ostreams = max_num_of_ostreams;
 
-        ogs_info("eNB-N2[%s] tac: %u max_num_of_ostreams : %d",
-            OGS_ADDR(enb->sctp.addr, buf), enb->supported_ta_list[0].tac, enb->max_num_of_ostreams);
+        ogs_info("eNB-N2[%s] max_num_of_ostreams : %d",
+            OGS_ADDR(enb->sctp.addr, buf), enb->max_num_of_ostreams);
 
         break;
 

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -186,6 +186,8 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         return;
     }
 
+    stats_write_list_enbs();
+
     enb->state.s1_setup_success = true;
     ogs_assert(OGS_OK == s1ap_send_s1_setup_response(enb));
 }

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -186,7 +186,7 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         return;
     }
 
-    stats_write_list_enbs();
+    stats_write_list_mme_enbs();
 
     enb->state.s1_setup_success = true;
     ogs_assert(OGS_OK == s1ap_send_s1_setup_response(enb));

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -877,7 +877,6 @@ static void stats_add_sgwc_ue(sgwc_ue_t *sgwc_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_ue);
     ogs_write_file_value("sgwc/num_ues", buffer);
-    ogs_add_line_file("sgwc/list_ues", sgwc_ue->imsi_bcd);
 }
 
 static void stats_remove_sgwc_ue(sgwc_ue_t *sgwc_ue)
@@ -888,37 +887,24 @@ static void stats_remove_sgwc_ue(sgwc_ue_t *sgwc_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_ue);
     ogs_write_file_value("sgwc/num_ues", buffer);
-    ogs_remove_line_file("sgwc/list_ues", sgwc_ue->imsi_bcd);
 }
 
 static void stats_add_sgwc_session(sgwc_sess_t *sess)
 {
-    char buffer[150];
-
     num_of_sgwc_sess = num_of_sgwc_sess + 1;
     ogs_info("[Added] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
 
+    char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_sess);
     ogs_write_file_value("sgwc/num_sessions", buffer);
-
-    sprintf(buffer, "imsi:%s apn:%s",
-        sess->sgwc_ue->imsi_bcd ? sess->sgwc_ue->imsi_bcd : "",
-        sess->session.name ? sess->session.name : "");
-    ogs_add_line_file("sgwc/list_sessions", buffer);
 }
 
 static void stats_remove_sgwc_session(sgwc_sess_t *sess)
 {
-    char buffer[150];
-
     num_of_sgwc_sess = num_of_sgwc_sess - 1;
     ogs_info("[Removed] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
 
+    char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_sess);
     ogs_write_file_value("sgwc/num_sessions", buffer);
-
-    sprintf(buffer, "imsi:%s apn:%s",
-        sess->sgwc_ue->imsi_bcd ? sess->sgwc_ue->imsi_bcd : "",
-        sess->session.name ? sess->session.name : "");
-    ogs_remove_line_file("sgwc/list_sessions", buffer);
 }

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -35,10 +35,12 @@ static int context_initialized = 0;
 static int num_of_sgwc_ue = 0;
 static int num_of_sgwc_sess = 0;
 
-static void stats_add_sgwc_session(sgwc_sess_t *sess);
-static void stats_remove_sgwc_session(sgwc_sess_t *sess);
-static void stats_add_sgwc_ue(sgwc_ue_t *sgwc_ue);
-static void stats_remove_sgwc_ue(sgwc_ue_t *sgwc_ue);
+static void stats_write_list_sgwc_ues(void);
+static void stats_write_list_sgwc_sessions(void);
+static void stats_add_sgwc_session(void);
+static void stats_remove_sgwc_session(void);
+static void stats_add_sgwc_ue(void);
+static void stats_remove_sgwc_ue(void);
 
 void sgwc_context_init(void)
 {
@@ -210,7 +212,7 @@ sgwc_ue_t *sgwc_ue_add(uint8_t *imsi, int imsi_len)
 
     ogs_list_add(&self.sgw_ue_list, sgwc_ue);
 
-    stats_add_sgwc_ue(sgwc_ue);
+    stats_add_sgwc_ue();
 
     return sgwc_ue;
 }
@@ -227,7 +229,7 @@ int sgwc_ue_remove(sgwc_ue_t *sgwc_ue)
 
     ogs_pool_free(&sgwc_ue_pool, sgwc_ue);
 
-    stats_remove_sgwc_ue(sgwc_ue);
+    stats_remove_sgwc_ue();
     
     return OGS_OK;
 }
@@ -298,7 +300,7 @@ sgwc_sess_t *sgwc_sess_add(sgwc_ue_t *sgwc_ue, char *apn)
 
     ogs_list_add(&sgwc_ue->sess_list, sess);
 
-    stats_add_sgwc_session(sess);
+    stats_add_sgwc_session();
 
     return sess;
 }
@@ -416,7 +418,7 @@ int sgwc_sess_remove(sgwc_sess_t *sess)
 
     ogs_pool_free(&sgwc_sess_pool, sess);
 
-    stats_remove_sgwc_session(sess);
+    stats_remove_sgwc_session();
 
     return OGS_OK;
 }
@@ -869,7 +871,51 @@ sgwc_tunnel_t *sgwc_ul_tunnel_in_bearer(sgwc_bearer_t *bearer)
             OGS_GTP2_F_TEID_S1_U_SGW_GTP_U);
 }
 
-static void stats_add_sgwc_ue(sgwc_ue_t *sgwc_ue)
+static void stats_write_list_sgwc_ues(void) {
+    sgwc_ue_t *sgwc_ue = NULL;
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+
+    ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
+        ptr += sprintf(ptr, "%s\n", sgwc_ue->imsi_bcd);
+    }
+
+    ogs_write_file_value("sgwc/list_ues", buffer);
+    ogs_free(buffer);
+}
+
+#define MAX_APN 63
+#define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
+
+static void stats_write_list_sgwc_sessions(void) {
+    sgwc_ue_t *sgwc_ue = NULL;
+    sgwc_sess_t *sess = NULL;
+
+    char buf1[OGS_ADDRSTRLEN];
+    char buf2[OGS_ADDRSTRLEN];
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+
+    ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
+        ogs_list_for_each(&sgwc_ue->sess_list, sess) {
+            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s\n",
+                sgwc_ue->imsi_bcd,
+                sess->session.name ? sess->session.name : "",
+                sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(&sess->session.ue_ip.addr, buf1) : "",
+                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "");
+        }
+    }
+
+    ogs_write_file_value("sgwc/list_sessions", buffer);
+    ogs_free(buffer);
+}
+
+
+static void stats_add_sgwc_ue(void)
 {
     num_of_sgwc_ue = num_of_sgwc_ue + 1;
     ogs_info("[Added] Number of SGWC-UEs is now %d", num_of_sgwc_ue);
@@ -877,9 +923,10 @@ static void stats_add_sgwc_ue(sgwc_ue_t *sgwc_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_ue);
     ogs_write_file_value("sgwc/num_ues", buffer);
+    stats_write_list_sgwc_ues();
 }
 
-static void stats_remove_sgwc_ue(sgwc_ue_t *sgwc_ue)
+static void stats_remove_sgwc_ue(void)
 {
     num_of_sgwc_ue = num_of_sgwc_ue - 1;
     ogs_info("[Removed] Number of SGWC-UEs is now %d", num_of_sgwc_ue);
@@ -887,9 +934,10 @@ static void stats_remove_sgwc_ue(sgwc_ue_t *sgwc_ue)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_ue);
     ogs_write_file_value("sgwc/num_ues", buffer);
+    stats_write_list_sgwc_ues();
 }
 
-static void stats_add_sgwc_session(sgwc_sess_t *sess)
+static void stats_add_sgwc_session(void)
 {
     num_of_sgwc_sess = num_of_sgwc_sess + 1;
     ogs_info("[Added] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
@@ -897,9 +945,10 @@ static void stats_add_sgwc_session(sgwc_sess_t *sess)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_sess);
     ogs_write_file_value("sgwc/num_sessions", buffer);
+    stats_write_list_sgwc_sessions();
 }
 
-static void stats_remove_sgwc_session(sgwc_sess_t *sess)
+static void stats_remove_sgwc_session(void)
 {
     num_of_sgwc_sess = num_of_sgwc_sess - 1;
     ogs_info("[Removed] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
@@ -907,4 +956,5 @@ static void stats_remove_sgwc_session(sgwc_sess_t *sess)
     char buffer[20];
     sprintf(buffer, "%d\n", num_of_sgwc_sess);
     ogs_write_file_value("sgwc/num_sessions", buffer);
+    stats_write_list_sgwc_sessions();
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1441,6 +1441,8 @@ uint8_t smf_sess_set_ue_ip(smf_sess_t *sess)
         ogs_assert_if_reached();
     }
 
+    stats_write_list_smf_sessions();
+
     return cause_value;
 }
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2904,8 +2904,8 @@ void stats_write_list_smf_sessions(void) {
             ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s\n",
                 smf_ue->imsi_bcd,
                 sess->session.name ? sess->session.name : "",
-                sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(sess->session.ue_ip.addr, buf1) : "",
-                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(sess->session.ue_ip.addr6, buf2) : "");
+                sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(&sess->session.ue_ip.addr, buf1) : "",
+                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "");
         }
     }
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -37,8 +37,6 @@ static int context_initialized = 0;
 static int num_of_smf_ue = 0;
 static int num_of_smf_sess = 0;
 
-static void stats_write_list_smf_ues(void);
-static void stats_write_list_smf_sessions(void);
 static void stats_add_smf_session(void);
 static void stats_remove_smf_session(void);
 static void stats_add_smf_ue(void);

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -509,6 +509,9 @@ void smf_pf_identifier_pool_final(smf_bearer_t *bearer);
 void smf_pf_precedence_pool_init(smf_sess_t *sess);
 void smf_pf_precedence_pool_final(smf_sess_t *sess);
 
+void stats_write_list_smf_ues(void);
+void stats_write_list_smf_sessions(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -27,8 +27,6 @@
 
 #include "ipfw/ipfw2.h"
 
-static void stats_add_smf_session_info(smf_sess_t *sess);
-
 static void pfcp_sess_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
     uint8_t type;
@@ -270,7 +268,7 @@ uint8_t smf_s5c_handle_create_session_request(
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
-//    stats_add_smf_session_info(sess);
+   stats_write_list_smf_sessions();
 
     /* Remove all previous bearer */
     smf_bearer_remove_all(sess);
@@ -1421,19 +1419,4 @@ void smf_s5c_handle_bearer_resource_command(
         rv = ogs_gtp_xact_commit(xact);
         ogs_expect(rv == OGS_OK);
     }
-}
-
-static void stats_add_smf_session_info(smf_sess_t *sess)
-{
-    char buf1[OGS_ADDRSTRLEN];
-    char buf2[OGS_ADDRSTRLEN];
-    char buffer[150];
-
-    sprintf(buffer, "imsi:%s apn:%s ip4:%s ip6:%s sgw_teid:%x smf_teid:%x",
-        sess->smf_ue->imsi_bcd ? sess->smf_ue->imsi_bcd : "",
-        sess->session.name ? sess->session.name : "",
-        sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
-        sess->ipv6 ? OGS_INET6_NTOP(sess->ipv6->addr, buf2) : "",
-        sess->sgw_s5c_teid, sess->smf_n4_teid);
-    ogs_add_line_file("smf/list_sessions", buffer);
 }


### PR DESCRIPTION
The stats/logging functions actually needed more thought/work than initially realized. ca6654c reverted the changes for purposes of stability, and now this commit adds them back in, this time thoroughly tested and crash-proof.