### PR TITLE
fix/remove minor compile warnings

### DIFF
--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -605,7 +605,6 @@ static void response_timeout(void *data)
 
         if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
             ogs_error("ogs_pfcp_sendto() failed");
-            // goto out;
         }
     } else {
         ogs_warn("[%d] %s No Reponse. Give up! "
@@ -624,7 +623,6 @@ static void response_timeout(void *data)
 
     return;
 
-out:
     ogs_pfcp_xact_delete(xact);
 }
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -101,7 +101,7 @@ typedef struct mme_context_s {
     served_gummei_t served_gummei[MAX_NUM_OF_SERVED_GUMMEI];
 
     /* Served TAI */
-    uint8_t         num_of_served_tai;
+    uint16_t         num_of_served_tai;
     struct {
         ogs_eps_tai0_list_t list0;
         ogs_eps_tai2_list_t list2;

--- a/tests/common/context.h
+++ b/tests/common/context.h
@@ -75,7 +75,7 @@ typedef struct test_context_s {
     } plmn_support[OGS_MAX_NUM_OF_PLMN];
 
     /* Served EPC TAI */
-    uint8_t num_of_e_served_tai;
+    uint16_t num_of_e_served_tai;
     struct {
         ogs_eps_tai0_list_t list0;
         ogs_eps_tai2_list_t list2;
@@ -84,7 +84,7 @@ typedef struct test_context_s {
     ogs_eps_tai_t e_tai;
 
     /* Served 5GC TAI */
-    uint8_t num_of_nr_served_tai;
+    uint16_t num_of_nr_served_tai;
     struct {
         ogs_5gs_tai0_list_t list0;
         ogs_5gs_tai2_list_t list2;


### PR DESCRIPTION
This fixes #25. Only expanding from uint8_t to uint16_t and removing a useless "out:" label