### PR TITLE
update UPS SEIDs after PFCP re-association

### DIFF
--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -68,12 +68,21 @@ typedef struct sgwc_ue_s {
     ogs_gtp_node_t  *gnode;
 } sgwc_ue_t;
 
+enum PFCP_STATES {
+    PFCP_ENTRY,
+    PFCP_WAIT_ESTABLISHMENT,
+    PFCP_ESTABLISHED,
+    PFCP_WAIT_DELETION,
+    PFCP_DELETED
+};
+
 #define SGWC_SESS(pfcp_sess) ogs_container_of(pfcp_sess, sgwc_sess_t, pfcp)
 typedef struct sgwc_sess_s {
     ogs_lnode_t     lnode;          /* A node of list_t */
     uint32_t        index;          /**< An index of this node */
 
     ogs_pfcp_sess_t pfcp;           /* PFCP session context */
+    int pfcp_state;                 /* PFCP state machine */
 
     uint32_t        sgw_s5c_teid;   /* SGW-S5C-TEID is derived from INDEX */
     uint32_t        pgw_s5c_teid;   /* PGW-S5C-TEID is received from PGW */

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -233,6 +233,13 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
                 break;
             }
 
+            if (sess && sess->pfcp_state == PFCP_ESTABLISHED) {
+                ogs_warn("Already received SER for this session");
+                sgwc_sxa_handle_session_reestablishment(
+                    sess, xact, &message->pfcp_session_establishment_response);
+                break;
+            }
+
             if (!e->gtp_message) {
                 ogs_warn("No GTP Message Context");
                 break;

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -124,6 +124,25 @@ static void bearer_timeout(ogs_gtp_xact_t *xact, void *data)
     }
 }
 
+void sgwc_sxa_handle_session_reestablishment(
+        sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
+        ogs_pfcp_session_establishment_response_t *pfcp_rsp)
+{
+    ogs_assert(sess);
+    ogs_assert(pfcp_xact);
+    ogs_assert(pfcp_rsp);
+
+    ogs_pfcp_xact_commit(pfcp_xact);
+
+    // I *think* the only thing we need to do here is check/udpate up_f_seid
+    ogs_pfcp_f_seid_t *up_f_seid = NULL;
+    up_f_seid = pfcp_rsp->up_f_seid.data;
+    ogs_assert(up_f_seid);
+    sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
+
+    return;
+}
+
 void sgwc_sxa_handle_session_establishment_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_gtp2_message_t *recv_message,
@@ -305,6 +324,8 @@ void sgwc_sxa_handle_session_establishment_response(
     up_f_seid = pfcp_rsp->up_f_seid.data;
     ogs_assert(up_f_seid);
     sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
+
+    sess->pfcp_state = PFCP_ESTABLISHED;
 
     pgw_s5c_teid = create_session_request->
         pgw_s5_s8_address_for_control_plane_or_pmip.data;

--- a/src/sgwc/sxa-handler.h
+++ b/src/sgwc/sxa-handler.h
@@ -26,6 +26,10 @@
 extern "C" {
 #endif
 
+
+void sgwc_sxa_handle_session_reestablishment(
+        sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
+        ogs_pfcp_session_establishment_response_t *pfcp_rsp);
 void sgwc_sxa_handle_session_establishment_response(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_gtp2_message_t *gtp_message,

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -732,7 +732,10 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
     smf_ue_t *smf_ue = NULL;
     smf_sess_t *sess = NULL;
     ogs_pkbuf_t *pkbuf = NULL;
+
+    ogs_pfcp_xact_t *pfcp_xact = NULL;
     ogs_pfcp_message_t *pfcp_message = NULL;
+    uint8_t pfcp_cause;
 
     ogs_nas_5gs_message_t *nas_message = NULL;
 
@@ -1128,12 +1131,21 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
         break;
 
     case SMF_EVT_N4_MESSAGE:
+        pfcp_xact = e->pfcp_xact;
+        ogs_assert(pfcp_xact);
         pfcp_message = e->pfcp_message;
         ogs_assert(pfcp_message);
 
         switch (pfcp_message->h.type) {
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
             ogs_warn("PFCP session is already established; ignoring PFCP-SER");
+            if (pfcp_xact->epc) {
+                pfcp_cause = smf_epc_n4_handle_session_establishment_response(
+                        sess, pfcp_xact,
+                        &pfcp_message->pfcp_session_establishment_response);
+            } else {
+                ogs_error("5GC PFCP re-establish session not yet written");
+            }
             break;
 
         default:

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -732,6 +732,7 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
     smf_ue_t *smf_ue = NULL;
     smf_sess_t *sess = NULL;
     ogs_pkbuf_t *pkbuf = NULL;
+    ogs_pfcp_message_t *pfcp_message = NULL;
 
     ogs_nas_5gs_message_t *nas_message = NULL;
 
@@ -1123,6 +1124,21 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
         default:
             ogs_error("Unknown message[%d]", e->ngap.type);
+        }
+        break;
+
+    case SMF_EVT_N4_MESSAGE:
+        pfcp_message = e->pfcp_message;
+        ogs_assert(pfcp_message);
+
+        switch (pfcp_message->h.type) {
+        case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
+            ogs_warn("PFCP session is already established; ignoring PFCP-SER");
+            break;
+
+        default:
+            ogs_error("cannot handle PFCP message type[%d]",
+                    pfcp_message->h.type);
         }
         break;
 

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -684,7 +684,6 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
     uint8_t cause_value = OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 
     smf_bearer_t *bearer = NULL;
-    ogs_gtp_xact_t *gtp_xact = NULL;
 
     ogs_pfcp_f_seid_t *up_f_seid = NULL;
 
@@ -693,9 +692,6 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
     ogs_assert(rsp);
 
     ogs_debug("Session Establishment Response [epc]");
-
-    gtp_xact = xact->assoc_xact;
-    ogs_assert(gtp_xact);
 
     ogs_pfcp_xact_commit(xact);
 


### PR DESCRIPTION
If a UPS de-associates and re-associates PFCP it eventually gets out of sync with the CPS with respect to SEID values. This is because the UPS will generate new SEID values each time (i.e. after Session-Set-Delete and Session-Establishment) and returns them in the Session-Establishment-Response, but if session is already established, the CPS will ignore these values.