### PR TITLE
add stats reporting to ups

### DIFF
--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -27,10 +27,6 @@ static OGS_POOL(sgwu_sess_pool, sgwu_sess_t);
 
 static int context_initialized = 0;
 
-static int num_of_sgwu_sess = 0;
-static void stats_add_sgwu_session(void);
-static void stats_remove_sgwu_session(void);
-
 void sgwu_context_init(void)
 {
     ogs_assert(context_initialized == 0);
@@ -166,7 +162,7 @@ sgwu_sess_t *sgwu_sess_add(ogs_pfcp_f_seid_t *cp_f_seid)
     ogs_info("[Added] Number of SGWU-Sessions is now %d",
             ogs_list_count(&self.sess_list));
 
-    stats_add_sgwu_session();
+    stats_update_sgwu_sessions();
 
     return sess;
 }
@@ -190,7 +186,7 @@ int sgwu_sess_remove(sgwu_sess_t *sess)
     ogs_info("[Removed] Number of SGWU-sessions is now %d",
             ogs_list_count(&self.sess_list));
 
-    stats_remove_sgwu_session();
+    stats_update_sgwu_sessions();
 
     return OGS_OK;
 }
@@ -261,45 +257,21 @@ sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)
 
 #define MAX_SESSION_STRING_LEN (22 + 16 + 16)
 
-//     ogs_info("UE F-SEID[CP:0x%lx UP:0x%lx]",
-        // (long)sess->sgwu_sxa_seid, (long)sess->sgwc_sxa_f_seid.seid);
-
-
-void stats_write_list_sgwu_sessions(void) {
+void stats_update_sgwu_sessions(void)
+{
     sgwu_sess_t *sess = NULL;
-
     char *buffer = NULL;
     char *ptr = NULL;
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    char num[20];
+    sprintf(num, "%d\n", ogs_list_count(&self.sess_list));
+    ogs_write_file_value("sgwu/num_sessions", num);
 
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sess_list, sess) {
         ptr += sprintf(ptr, "seid_cp:0x%lx seid_up:0x%lx\n",
             (long)sess->sgwu_sxa_seid, (long)sess->sgwc_sxa_f_seid.seid);
     }
-
     ogs_write_file_value("sgwu/list_sessions", buffer);
     ogs_free(buffer);
-}
-
-static void stats_add_sgwu_session(void)
-{
-    num_of_sgwu_sess = num_of_sgwu_sess + 1;
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_sgwu_sess);
-    ogs_write_file_value("sgwu/num_sessions", buffer);
-
-    stats_write_list_sgwu_sessions();
-}
-
-static void stats_remove_sgwu_session(void)
-{
-    num_of_sgwu_sess = num_of_sgwu_sess - 1;
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_sgwu_sess);
-    ogs_write_file_value("sgwu/num_sessions", buffer);
-
-    stats_write_list_sgwu_sessions();
 }

--- a/src/sgwu/context.h
+++ b/src/sgwu/context.h
@@ -75,6 +75,8 @@ sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_seid(uint64_t seid);
 sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_f_seid(ogs_pfcp_f_seid_t *f_seid);
 sgwu_sess_t *sgwu_sess_find_by_sgwu_sxa_seid(uint64_t seid);
 
+void stats_write_list_sgwu_sessions(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sgwu/context.h
+++ b/src/sgwu/context.h
@@ -75,7 +75,7 @@ sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_seid(uint64_t seid);
 sgwu_sess_t *sgwu_sess_find_by_sgwc_sxa_f_seid(ogs_pfcp_f_seid_t *f_seid);
 sgwu_sess_t *sgwu_sess_find_by_sgwu_sxa_seid(uint64_t seid);
 
-void stats_write_list_sgwu_sessions(void);
+void stats_update_sgwu_sessions(void);
 
 #ifdef __cplusplus
 }

--- a/src/sgwu/init.c
+++ b/src/sgwu/init.c
@@ -65,6 +65,15 @@ int sgwu_initialize()
     initialized = 1;
 
     ogs_write_file_start("sgwu_start_time");
+    ogs_write_file_subdir("sgwu");
+
+    char buffer[25];
+    sprintf(buffer, "%d\n", 0);
+    ogs_write_file_value("sgwu/num_sessions", buffer);
+
+    sprintf(buffer, "List of Active Sessions\n");
+    ogs_write_file_value("sgwu/list_sessions", buffer);
+
     return OGS_OK;
 }
 

--- a/src/sgwu/init.c
+++ b/src/sgwu/init.c
@@ -66,14 +66,8 @@ int sgwu_initialize()
 
     ogs_write_file_start("sgwu_start_time");
     ogs_write_file_subdir("sgwu");
-
-    char buffer[25];
-    sprintf(buffer, "%d\n", 0);
-    ogs_write_file_value("sgwu/num_sessions", buffer);
-
-    sprintf(buffer, "List of Active Sessions\n");
-    ogs_write_file_value("sgwu/list_sessions", buffer);
-
+    stats_update_sgwu_sessions();
+    
     return OGS_OK;
 }
 

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -28,7 +28,12 @@ static OGS_POOL(upf_sess_pool, upf_sess_t);
 
 static int context_initialized = 0;
 
+static int num_of_upf_sess = 0;
+
 static void upf_sess_urr_acc_remove_all(upf_sess_t *sess);
+
+static void stats_add_upf_session(void);
+static void stats_remove_upf_session(void);
 
 void upf_context_init(void)
 {
@@ -178,6 +183,8 @@ upf_sess_t *upf_sess_add(ogs_pfcp_f_seid_t *cp_f_seid)
     ogs_info("[Added] Number of UPF-Sessions is now %d",
             ogs_list_count(&self.sess_list));
 
+    stats_add_upf_session();
+
     return sess;
 }
 
@@ -205,12 +212,18 @@ int upf_sess_remove(upf_sess_t *sess)
         ogs_pfcp_ue_ip_free(sess->ipv6);
     }
 
+    if (sess->dnn) {
+        ogs_free(sess->dnn);
+    }
+
     ogs_pfcp_pool_final(&sess->pfcp);
 
     ogs_pool_free(&upf_sess_pool, sess);
 
     ogs_info("[Removed] Number of UPF-sessions is now %d",
             ogs_list_count(&self.sess_list));
+
+    stats_remove_upf_session();
 
     return OGS_OK;
 }
@@ -394,10 +407,12 @@ uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
                 pdr->dnn ? pdr->dnn : "");
     }
 
+    sess->dnn = ogs_strdup(pdr->dnn);
+
     ogs_info("UE F-SEID[CP:0x%lx UP:0x%lx] "
              "APN[%s] PDN-Type[%d] IPv4[%s] IPv6[%s]",
         (long)sess->upf_n4_seid, (long)sess->smf_n4_f_seid.seid,
-        pdr->dnn, session_type,
+        sess->dnn, session_type,
         sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
         sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
 
@@ -597,4 +612,50 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
             sess->urr_acc[i].t_time_threshold = NULL;
         }
     }
+}
+
+#define MAX_APN 63
+#define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
+
+void stats_write_list_upf_sessions(void) {
+    upf_sess_t *sess = NULL;
+
+    char buf1[OGS_ADDRSTRLEN];
+    char buf2[OGS_ADDRSTRLEN];
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+
+    ogs_list_for_each(&self.sess_list, sess) {
+        ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",
+            sess->dnn ? sess->dnn : "",
+            sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
+            sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
+    }
+
+    ogs_write_file_value("upf/list_sessions", buffer);
+    ogs_free(buffer);
+}
+
+static void stats_add_upf_session(void)
+{
+    num_of_upf_sess = num_of_upf_sess + 1;
+
+    char buffer[20];
+    sprintf(buffer, "%d\n", num_of_upf_sess);
+    ogs_write_file_value("upf/num_sessions", buffer);
+
+    stats_write_list_upf_sessions();
+}
+
+static void stats_remove_upf_session(void)
+{
+    num_of_upf_sess = num_of_upf_sess - 1;
+
+    char buffer[20];
+    sprintf(buffer, "%d\n", num_of_upf_sess);
+    ogs_write_file_value("upf/num_sessions", buffer);
+
+    stats_write_list_upf_sessions();
 }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -615,7 +615,7 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 }
 
 #define MAX_APN 63
-#define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
+#define MAX_SESSION_STRING_LEN (21 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
 
 void stats_write_list_upf_sessions(void) {
     upf_sess_t *sess = NULL;

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -407,6 +407,9 @@ uint8_t upf_sess_set_ue_ip(upf_sess_t *sess,
                 pdr->dnn ? pdr->dnn : "");
     }
 
+    if (sess->dnn) {
+        ogs_free(sess->dnn);
+    }
     sess->dnn = ogs_strdup(pdr->dnn);
 
     ogs_info("UE F-SEID[CP:0x%lx UP:0x%lx] "

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -618,7 +618,7 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 }
 
 #define MAX_APN 63
-#define MAX_SESSION_STRING_LEN (21 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
+#define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16)
 
 void stats_write_list_upf_sessions(void) {
     upf_sess_t *sess = NULL;
@@ -631,10 +631,11 @@ void stats_write_list_upf_sessions(void) {
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
 
     ogs_list_for_each(&self.sess_list, sess) {
-        ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",
+        ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s seid_cp:0x%lx seid_up:0x%lx\n",
             sess->dnn ? sess->dnn : "",
             sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
-            sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
+            sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "",
+            (long)sess->upf_n4_seid, (long)sess->smf_n4_f_seid.seid);
     }
 
     ogs_write_file_value("upf/list_sessions", buffer);

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -97,6 +97,10 @@ typedef struct upf_sess_s {
     /* APN Configuration */
     ogs_pfcp_ue_ip_t *ipv4;
     ogs_pfcp_ue_ip_t *ipv6;
+    union {
+        char *apn;
+        char *dnn;
+    };
 
     char            *gx_sid;            /* Gx Session ID */
     ogs_pfcp_node_t *pfcp_node;
@@ -131,6 +135,8 @@ void upf_sess_urr_acc_fill_usage_report(upf_sess_t *sess, const ogs_pfcp_urr_t *
                                         ogs_pfcp_user_plane_report_t *report, unsigned int idx);
 void upf_sess_urr_acc_snapshot(upf_sess_t *sess, ogs_pfcp_urr_t *urr);
 void upf_sess_urr_acc_timers_setup(upf_sess_t *sess, ogs_pfcp_urr_t *urr);
+
+void stats_write_list_upf_sessions(void);
 
 #ifdef __cplusplus
 }

--- a/src/upf/context.h
+++ b/src/upf/context.h
@@ -136,7 +136,7 @@ void upf_sess_urr_acc_fill_usage_report(upf_sess_t *sess, const ogs_pfcp_urr_t *
 void upf_sess_urr_acc_snapshot(upf_sess_t *sess, ogs_pfcp_urr_t *urr);
 void upf_sess_urr_acc_timers_setup(upf_sess_t *sess, ogs_pfcp_urr_t *urr);
 
-void stats_write_list_upf_sessions(void);
+void stats_update_upf_sessions(void);
 
 #ifdef __cplusplus
 }

--- a/src/upf/init.c
+++ b/src/upf/init.c
@@ -69,13 +69,7 @@ int upf_initialize()
 
     ogs_write_file_start("upf_start_time");
     ogs_write_file_subdir("upf");
-
-    char buffer[25];
-    sprintf(buffer, "%d\n", 0);
-    ogs_write_file_value("upf/num_sessions", buffer);
-
-    sprintf(buffer, "List of Active Sessions\n");
-    ogs_write_file_value("upf/list_sessions", buffer);
+    stats_update_upf_sessions();
 
     return OGS_OK;
 }

--- a/src/upf/init.c
+++ b/src/upf/init.c
@@ -68,6 +68,15 @@ int upf_initialize()
     initialized = 1;
 
     ogs_write_file_start("upf_start_time");
+    ogs_write_file_subdir("upf");
+
+    char buffer[25];
+    sprintf(buffer, "%d\n", 0);
+    ogs_write_file_value("upf/num_sessions", buffer);
+
+    sprintf(buffer, "List of Active Sessions\n");
+    ogs_write_file_value("upf/list_sessions", buffer);
+
     return OGS_OK;
 }
 


### PR DESCRIPTION
Major PR adds the following stats functions to the UPS (upf and sgwu):
### /tmp/open5gs/{sgwu, upf}/num_sessions: the number of active sessions
### /tmp/open5gs/{sgwu, upf}/list_sessions: for each active session has the following vars:
- apn: (UPF only, blank if not assigned)
- ip4: (UPF only, blank if not assigned)
- ip6: (UPF only, blank if not assigned)
- seid_cp:  the SEID used by the control plane to manage tunnels (i.e. from sgwc-sgwu and from smf-upf)
- seid_up: the SEID used by forwarding tunnels in the data-plane (i.e. eNB-sgwu-upf-Internet)