### PR TITLE
increase OGS_MAX_NUM_OF_SERVED_TAI from 16 to 256

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # What Is This Repo?
 
 This is our (Althea's) branch of [open5gs](https://github.com/open5gs/open5gs). Our team is firmly committed to open-sourcing and upstreaming all our contributions to open5gs whenever possible and desired by the community; this repo only holds commits that are either (a) still under active testing/development or (b) not desired by the greater open5gs community. Every change from upstream open5gs will be explained/listed below.
+
+## Number of Served TAC/TAI
+open5gs has a limit of 16 different served TAIs hard-coded in OGS_MAX_NUM_OF_SERVED_TAI. Althea's KeyLTE architecture relies on many more than that: each edge KeyLTE router has its own TAC/TAI. We have currently set OGS_MAX_NUM_OF_SERVED_TAI to 256; this might increase again in the future.

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -173,7 +173,7 @@ static void app_context_prepare(void)
     self.sockopt.no_delay = true;
 
 #define MAX_NUM_OF_UE               1024    /* Num of UEs */
-#define MAX_NUM_OF_PEER             64      /* Num of Peer */
+#define MAX_NUM_OF_PEER             256      /* Num of Peer */
 
     self.max.ue = MAX_NUM_OF_UE;
     self.max.peer = MAX_NUM_OF_PEER;

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -403,7 +403,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         const char *hostname[OGS_MAX_NUM_OF_HOSTNAME];
                         uint16_t port = self.pfcp_port;
                         uint16_t tac[OGS_MAX_NUM_OF_TAI] = {0,};
-                        uint8_t num_of_tac = 0;
+                        uint16_t num_of_tac = 0;
                         const char *dnn[OGS_MAX_NUM_OF_DNN];
                         uint8_t num_of_dnn = 0;
                         uint32_t e_cell_id[OGS_MAX_NUM_OF_CELL_ID] = {0,};

--- a/lib/proto/types.h
+++ b/lib/proto/types.h
@@ -81,7 +81,7 @@ extern "C" {
 #define OGS_MAX_PCO_LEN                 251
 #define OGS_MAX_FQDN_LEN                256
 
-#define OGS_MAX_NUM_OF_SERVED_TAI       16
+#define OGS_MAX_NUM_OF_SERVED_TAI       256
 #define OGS_MAX_NUM_OF_ALGORITHM        8
 
 #define OGS_MAX_NUM_OF_BPLMN            6

--- a/src/amf/context.h
+++ b/src/amf/context.h
@@ -53,7 +53,7 @@ typedef struct amf_context_s {
     ogs_guami_t served_guami[MAX_NUM_OF_SERVED_GUAMI];
 
     /* Served TAI */
-    uint8_t num_of_served_tai;
+    uint16_t num_of_served_tai;
     struct {
         ogs_5gs_tai0_list_t list0;
         ogs_5gs_tai2_list_t list2;
@@ -128,7 +128,7 @@ typedef struct amf_gnb_s {
     uint16_t        max_num_of_ostreams;/* SCTP Max num of outbound streams */
     uint16_t        ostream_id;         /* gnb_ostream_id generator */
 
-    uint8_t         num_of_supported_ta_list;
+    uint16_t         num_of_supported_ta_list;
     struct {
         ogs_uint24_t tac;
         uint8_t num_of_bplmn_list;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -1297,7 +1297,7 @@ int mme_context_parse_config()
                         const char *hostname[OGS_MAX_NUM_OF_HOSTNAME];
                         uint16_t port = ogs_gtp_self()->gtpc_port;
                         uint16_t tac[OGS_MAX_NUM_OF_TAI] = {0,};
-                        uint8_t num_of_tac = 0;
+                        uint16_t num_of_tac = 0;
                         uint32_t e_cell_id[OGS_MAX_NUM_OF_CELL_ID] = {0,};
                         uint8_t num_of_e_cell_id = 0;
 

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -102,7 +102,7 @@ typedef struct mme_context_s {
     served_gummei_t served_gummei[MAX_NUM_OF_SERVED_GUMMEI];
 
     /* Served TAI */
-    uint8_t         num_of_served_tai;
+    uint16_t         num_of_served_tai;
     struct {
         ogs_eps_tai0_list_t list0;
         ogs_eps_tai2_list_t list2;

--- a/tests/common/context.h
+++ b/tests/common/context.h
@@ -75,7 +75,7 @@ typedef struct test_context_s {
     } plmn_support[OGS_MAX_NUM_OF_PLMN];
 
     /* Served EPC TAI */
-    uint8_t num_of_e_served_tai;
+    uint16_t num_of_e_served_tai;
     struct {
         ogs_eps_tai0_list_t list0;
         ogs_eps_tai2_list_t list2;
@@ -84,7 +84,7 @@ typedef struct test_context_s {
     ogs_eps_tai_t e_tai;
 
     /* Served 5GC TAI */
-    uint8_t num_of_nr_served_tai;
+    uint16_t num_of_nr_served_tai;
     struct {
         ogs_5gs_tai0_list_t list0;
         ogs_5gs_tai2_list_t list2;


### PR DESCRIPTION
each KeyLTE edge-router gets its own served TAI so we obviously need more than 16. 256 seems good for now but we might go even higher in the future.