### PR TITLE
add send_asr PFCP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,9 @@
 This is our (Althea's) branch of [open5gs](https://github.com/open5gs/open5gs). Our team is firmly committed to open-sourcing and upstreaming all our contributions to open5gs whenever possible and desired by the community; this repo only holds commits that are either (a) still under active testing/development or (b) not desired by the greater open5gs community. Every change from upstream open5gs will be explained/listed below.
 
 ## Number of Served TAC/TAI
-open5gs has a limit of 16 different served TAIs hard-coded in OGS_MAX_NUM_OF_SERVED_TAI. Althea's KeyLTE architecture relies on many more than that: each edge KeyLTE router has its own TAC/TAI. We have currently set OGS_MAX_NUM_OF_SERVED_TAI to 256; this might increase again in the future.
+open5gs has a limit of 16 different served TAIs hard-coded in `OGS_MAX_NUM_OF_SERVED_TAI`. Althea's KeyLTE architecture relies on many more than that: each edge KeyLTE router has its own TAC/TAI. We have currently set `OGS_MAX_NUM_OF_SERVED_TAI` to 256; this might increase again in the future.
+
+## PFCP Send_ASR Option
+When configuring a node's PFCP connection to another node, you now have the option of adding `send_asr: false` to the configuration yaml. This bool (which defaults to `true`) indicates whether the node should send PFCP AssociationSetupRequests or not.
+
+The reason we need this bool/option is to turn it off for the CPS side. To allow KeyLTE routers to be seamlessly added to the existing CPS without requiring a reboot, we have to define all 256 served TAIs in the CPS configuration. Without this option, the CPS logs are full of errors trying to send ASR messages to KeyLTE routers that don't yet exist.

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -402,6 +402,7 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         int i, num = 0;
                         const char *hostname[OGS_MAX_NUM_OF_HOSTNAME];
                         uint16_t port = self.pfcp_port;
+                        bool send_asr = 1;
                         uint16_t tac[OGS_MAX_NUM_OF_TAI] = {0,};
                         uint16_t num_of_tac = 0;
                         const char *dnn[OGS_MAX_NUM_OF_DNN];
@@ -468,6 +469,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                             } else if (!strcmp(pfcp_key, "port")) {
                                 const char *v = ogs_yaml_iter_value(&pfcp_iter);
                                 if (v) port = atoi(v);
+                            } else if (!strcmp(pfcp_key, "send_asr")) {
+                                send_asr = ogs_yaml_iter_bool(&pfcp_iter);
                             } else if (!strcmp(pfcp_key, "tac")) {
                                 ogs_yaml_iter_t tac_iter;
                                 ogs_yaml_iter_recurse(&pfcp_iter, &tac_iter);
@@ -599,6 +602,8 @@ int ogs_pfcp_context_parse_config(const char *local, const char *remote)
                         node = ogs_pfcp_node_new(addr);
                         ogs_assert(node);
                         ogs_list_add(&self.pfcp_peer_list, node);
+
+                        node->send_asr = send_asr;
 
                         node->num_of_tac = num_of_tac;
                         if (num_of_tac != 0)

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -94,6 +94,8 @@ typedef struct ogs_pfcp_node_s {
     ogs_timer_t     *t_association; /* timer to retry to associate peer node */
     ogs_timer_t     *t_no_heartbeat; /* heartbeat timer to check aliveness */
 
+    bool            send_asr; /* send association setup request or just listen? */
+
     uint16_t        tac[OGS_MAX_NUM_OF_TAI];
     uint8_t         num_of_tac;
     const char*     dnn[OGS_MAX_NUM_OF_DNN];

--- a/lib/pfcp/path.h
+++ b/lib/pfcp/path.h
@@ -49,7 +49,7 @@ extern "C" {
         ogs_assert(ogs_pfcp_self()->pfcp_addr || ogs_pfcp_self()->pfcp_addr6); \
         \
         ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, pfcp_node) \
-            pfcp_node_fsm_init(pfcp_node, true); \
+            pfcp_node_fsm_init(pfcp_node, pfcp_node->send_asr); \
         \
     } while(0)
 


### PR DESCRIPTION
This adds a send_asr option to remote PFCP configuraiton. Default value (and previous behavior) is set to "true" but when set to "false", this side will NOT send PFCP association requests to the remote side. It will still listen to and respond to PFCP requests but they must be initiated from the remote side.

This is important for our architecture because we define a large number of UPS entities (sgwu and upf) by TAC, and as such the CPS must have corresponding entries in e.g. sgwc.yaml. But when these entities are offline, our CPS logs become filled up with failed association requests sent from the CPS to the UPSes. With CPS side setting this option to "false" the CPS stays silent and all online UPSes initiate PFCP sessions.
