### PR TITLE
Re-architect stats collection for CPS

### DIFF
--- a/src/mme/esm-handler.c
+++ b/src/mme/esm-handler.c
@@ -143,7 +143,7 @@ int esm_handle_pdn_connectivity_request(mme_bearer_t *bearer,
         return OGS_ERROR;
     }
 
-    stats_write_list_mme_sessions();
+    stats_update_mme_sessions();
 
     return OGS_OK;
 }
@@ -226,7 +226,7 @@ int esm_handle_information_response(mme_sess_t *sess,
         return OGS_ERROR;
     }
 
-    stats_write_list_mme_sessions();
+    stats_update_mme_sessions();
 
     return OGS_OK;
 }

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -52,13 +52,10 @@ static OGS_POOL(mme_bearer_pool, mme_bearer_t);
 static int context_initialized = 0;
 
 static int num_of_enb_ue = 0;
-static int num_of_mme_ue = 0;
 static int num_of_mme_sess = 0;
 
 static void stats_add_enb_ue(void);
 static void stats_remove_enb_ue(void);
-static void stats_add_mme_ue(mme_ue_t *mme_ue);
-static void stats_remove_mme_ue(mme_ue_t *mme_ue);
 static void stats_add_mme_session(mme_sess_t *sess);
 static void stats_remove_mme_session(mme_sess_t *sess);
 
@@ -1842,10 +1839,7 @@ mme_enb_t *mme_enb_add(ogs_sock_t *sock, ogs_sockaddr_t *addr)
     ogs_info("[Added] Number of eNBs is now %d",
             ogs_list_count(&self.enb_list));
 
-    char buffer[20];
-    sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
-    ogs_write_file_value("mme/num_enbs", buffer);
-    stats_write_list_mme_enbs();
+    stats_update_mme_enbs();
 
     return enb;
 }
@@ -1881,10 +1875,7 @@ int mme_enb_remove(mme_enb_t *enb)
     ogs_info("[Removed] Number of eNBs is now %d",
             ogs_list_count(&self.enb_list));
 
-    char buffer[20];
-    sprintf(buffer, "%d\n", ogs_list_count(&self.enb_list));
-    ogs_write_file_value("mme/num_enbs", buffer);
-    stats_write_list_mme_enbs();
+    stats_update_mme_enbs();
 
     return OGS_OK;
 }
@@ -2360,7 +2351,7 @@ mme_ue_t *mme_ue_add(enb_ue_t *enb_ue)
     ogs_info("[Added] Number of MME-UEs is now %d",
             ogs_list_count(&self.mme_ue_list));
 
-    stats_add_mme_ue(mme_ue);
+    stats_update_mme_ues();
 
     return mme_ue;
 }
@@ -2427,7 +2418,7 @@ void mme_ue_remove(mme_ue_t *mme_ue)
     ogs_info("[Removed] Number of MME-UEs is now %d",
             ogs_list_count(&self.mme_ue_list));
 
-    stats_remove_mme_ue(mme_ue);
+    stats_update_mme_ues();
 }
 
 void mme_ue_remove_all(void)
@@ -2724,7 +2715,7 @@ int mme_ue_set_imsi(mme_ue_t *mme_ue, char *imsi_bcd)
 
     ogs_hash_set(self.imsi_ue_hash, mme_ue->imsi, mme_ue->imsi_len, mme_ue);
 
-    stats_write_list_mme_ues();
+    stats_update_mme_ues();
 
     return OGS_OK;
 }
@@ -3547,78 +3538,6 @@ uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue)
     return 0;
 }
 
-void stats_write_list_mme_enbs(void) {
-    mme_enb_t *enb = NULL;
-
-    char buf[OGS_ADDRSTRLEN];
-    char *buffer = NULL;
-    char *ptr = NULL;
-    int i = 0;
-
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
-
-    ogs_list_for_each(&self.enb_list, enb) {
-        ptr += sprintf(ptr, "ip:%s tac:%u",
-            OGS_ADDR(enb->sctp.addr, buf),enb->supported_ta_list[0].tac);
-        for(i = 1; i < enb->num_of_supported_ta_list; i++) {
-            ptr += sprintf(ptr, ",%u",enb->supported_ta_list[i].tac);
-        }
-        ptr += sprintf(ptr, "\n");
-    }
-
-    ogs_write_file_value("mme/list_enbs", buffer);
-    ogs_free(buffer);
-}
-
-void stats_write_list_mme_ues(void) {
-    mme_ue_t *mme_ue = NULL;
-    char *buffer = NULL;
-    char *ptr = NULL;
-
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
-
-    ogs_list_for_each(&self.mme_ue_list, mme_ue) {
-        ptr += sprintf(ptr, "%s\n", mme_ue->imsi_bcd);
-    }
-
-    ogs_write_file_value("mme/list_ues", buffer);
-    ogs_free(buffer);
-}
-
-#define MAX_APN 63
-#define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
-
-void stats_write_list_mme_sessions(void) {
-    mme_ue_t *mme_ue = NULL;
-    mme_sess_t *sess = NULL;
-    ogs_session_t *session = NULL;
-
-    char buf1[OGS_ADDRSTRLEN];
-    char buf2[OGS_ADDRSTRLEN];
-    char *buffer = NULL;
-    char *ptr = NULL;
-
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-
-    ogs_list_for_each(&self.mme_ue_list, mme_ue) {
-        ogs_list_for_each(&mme_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s ", mme_ue->imsi_bcd);
-            if (sess->session) {
-                session = sess->session;
-                ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",
-                    session->name ? session->name : "",
-                    session->ue_ip.ipv4 ? OGS_INET_NTOP(session->ue_ip.addr, buf1) : "",
-                    session->ue_ip.ipv6 ? OGS_INET6_NTOP(session->ue_ip.addr6, buf2) : "");
-            } else {
-                ptr += sprintf(ptr, "apn: ip4: ip6:\n");
-            }
-        }
-    }
-
-    ogs_write_file_value("mme/list_sessions", buffer);
-    ogs_free(buffer);
-}
-
 static void stats_add_enb_ue(void)
 {
     mme_metrics_inst_global_inc(MME_METR_GLOB_GAUGE_ENB_UE);
@@ -3633,50 +3552,103 @@ static void stats_remove_enb_ue(void)
     ogs_info("[Removed] Number of eNB-UEs is now %d", num_of_enb_ue);
 }
 
-static void stats_add_mme_ue(mme_ue_t *enb_ue)
-{
-    num_of_mme_ue = num_of_mme_ue + 1;
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_mme_ue);
-    ogs_write_file_value("mme/num_ues", buffer);
-    stats_write_list_mme_ues();
-}
-
-static void stats_remove_mme_ue(mme_ue_t *enb_ue)
-{
-    num_of_mme_ue = num_of_mme_ue - 1;
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_mme_ue);
-    ogs_write_file_value("mme/num_ues", buffer);
-    stats_write_list_mme_ues();
-}
-
 static void stats_add_mme_session(mme_sess_t *sess)
 {
-    char buffer[20];
-
     mme_metrics_inst_global_inc(MME_METR_GLOB_GAUGE_MME_SESS);
     num_of_mme_sess = num_of_mme_sess + 1;
     ogs_info("[Added] Number of MME-Sessions is now %d", num_of_mme_sess);
 
-    sprintf(buffer, "%d\n", num_of_mme_sess);
-    ogs_write_file_value("mme/num_sessions", buffer);
-
-    stats_write_list_mme_sessions();
+    stats_update_mme_sessions();
 }
 
 static void stats_remove_mme_session(mme_sess_t *sess)
 {
-    char buffer[20];
 
     mme_metrics_inst_global_dec(MME_METR_GLOB_GAUGE_MME_SESS);
     num_of_mme_sess = num_of_mme_sess - 1;
     ogs_info("[Removed] Number of MME-Sessions is now %d", num_of_mme_sess);
 
-    sprintf(buffer, "%d\n", num_of_mme_sess);
-    ogs_write_file_value("mme/num_sessions", buffer);
+    stats_update_mme_sessions();
+}
 
-    stats_write_list_mme_sessions();
+void stats_update_mme_enbs(void)
+{
+    mme_enb_t *enb = NULL;
+
+    char buf[OGS_ADDRSTRLEN];
+    char *buffer = NULL;
+    char *ptr = NULL;
+    int i = 0;
+
+    char num[20];
+    sprintf(num, "%d\n", ogs_list_count(&self.enb_list));
+    ogs_write_file_value("mme/num_enbs", num);
+
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&self.enb_list, enb) {
+        ptr += sprintf(ptr, "ip:%s tac:%u",
+            OGS_ADDR(enb->sctp.addr, buf),enb->supported_ta_list[0].tac);
+        for(i = 1; i < enb->num_of_supported_ta_list; i++) {
+            ptr += sprintf(ptr, ",%u",enb->supported_ta_list[i].tac);
+        }
+        ptr += sprintf(ptr, "\n");
+    }
+
+    ogs_write_file_value("mme/list_enbs", buffer);
+    ogs_free(buffer);
+}
+
+void stats_update_mme_ues(void)
+{
+    mme_ue_t *mme_ue = NULL;
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    char num[20];
+    sprintf(num, "%d\n", ogs_list_count(&self.mme_ue_list));
+    ogs_write_file_value("mme/num_ues", num);
+
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&self.mme_ue_list, mme_ue) {
+        ptr += sprintf(ptr, "%s\n", mme_ue->imsi_bcd);
+    }
+    ogs_write_file_value("mme/list_ues", buffer);
+    ogs_free(buffer);
+}
+
+#define MAX_APN 63
+#define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
+
+void stats_update_mme_sessions(void)
+{
+    mme_ue_t *mme_ue = NULL;
+    mme_sess_t *sess = NULL;
+    ogs_session_t *session = NULL;
+
+    char buf1[OGS_ADDRSTRLEN];
+    char buf2[OGS_ADDRSTRLEN];
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    char num[20];
+    sprintf(num, "%d\n", num_of_mme_sess);
+    ogs_write_file_value("mme/num_sessions", num);
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&self.mme_ue_list, mme_ue) {
+        ogs_list_for_each(&mme_ue->sess_list, sess) {
+            ptr += sprintf(ptr, "imsi:%s ", mme_ue->imsi_bcd);
+            if (sess->session) {
+                session = sess->session;
+                ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",
+                    session->name ? session->name : "",
+                    session->ue_ip.ipv4 ? OGS_INET_NTOP(session->ue_ip.addr, buf1) : "",
+                    session->ue_ip.ipv6 ? OGS_INET6_NTOP(session->ue_ip.addr6, buf2) : "");
+            } else {
+                ptr += sprintf(ptr, "apn: ip4: ip6:\n");
+            }
+        }
+    }
+    ogs_write_file_value("mme/list_sessions", buffer);
+    ogs_free(buffer);
 }

--- a/src/mme/mme-context.h
+++ b/src/mme/mme-context.h
@@ -915,9 +915,9 @@ void mme_ebi_pool_clear(mme_ue_t *mme_ue);
 uint8_t mme_selected_int_algorithm(mme_ue_t *mme_ue);
 uint8_t mme_selected_enc_algorithm(mme_ue_t *mme_ue);
 
-void stats_write_list_mme_enbs(void);
-void stats_write_list_mme_ues(void);
-void stats_write_list_mme_sessions(void);
+void stats_update_mme_enbs(void);
+void stats_update_mme_ues(void);
+void stats_update_mme_sessions(void);
 
 #ifdef __cplusplus
 }

--- a/src/mme/mme-init.c
+++ b/src/mme/mme-init.c
@@ -84,17 +84,9 @@ int mme_initialize()
 
     ogs_write_file_start("mme_start_time");
     ogs_write_file_subdir("mme");
-
-    char buffer[25];
-    sprintf(buffer, "%d\n", 0);
-    ogs_write_file_value("mme/num_enbs", buffer);
-    ogs_write_file_value("mme/num_ues", buffer);
-    ogs_write_file_value("mme/num_sessions", buffer);
-
-    sprintf(buffer, "\n");    
-    ogs_write_file_value("mme/list_enbs", buffer);
-    ogs_write_file_value("mme/list_ues", buffer);
-    ogs_write_file_value("mme/list_sessions", buffer);
+    stats_update_mme_enbs();
+    stats_update_mme_ues();
+    stats_update_mme_sessions();
 
     return OGS_OK;
 }

--- a/src/mme/s1ap-handler.c
+++ b/src/mme/s1ap-handler.c
@@ -186,7 +186,7 @@ void s1ap_handle_s1_setup_request(mme_enb_t *enb, ogs_s1ap_message_t *message)
         return;
     }
 
-    stats_write_list_mme_enbs();
+    stats_update_mme_enbs();
 
     enb->state.s1_setup_success = true;
     ogs_assert(OGS_OK == s1ap_send_s1_setup_response(enb));

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -32,15 +32,10 @@ static OGS_POOL(sgwc_tunnel_pool, sgwc_tunnel_t);
 
 static int context_initialized = 0;
 
-static int num_of_sgwc_ue = 0;
 static int num_of_sgwc_sess = 0;
 
-static void stats_write_list_sgwc_ues(void);
-static void stats_write_list_sgwc_sessions(void);
 static void stats_add_sgwc_session(void);
 static void stats_remove_sgwc_session(void);
-static void stats_add_sgwc_ue(void);
-static void stats_remove_sgwc_ue(void);
 
 void sgwc_context_init(void)
 {
@@ -212,7 +207,10 @@ sgwc_ue_t *sgwc_ue_add(uint8_t *imsi, int imsi_len)
 
     ogs_list_add(&self.sgw_ue_list, sgwc_ue);
 
-    stats_add_sgwc_ue();
+    ogs_info("[Added] Number of SGWC-UEs is now %d",
+            ogs_list_count(&self.sgw_ue_list));
+
+    stats_update_sgwc_ues();
 
     return sgwc_ue;
 }
@@ -229,7 +227,10 @@ int sgwc_ue_remove(sgwc_ue_t *sgwc_ue)
 
     ogs_pool_free(&sgwc_ue_pool, sgwc_ue);
 
-    stats_remove_sgwc_ue();
+    ogs_info("[Removed] Number of SGWC-UEs is now %d",
+            ogs_list_count(&self.sgw_ue_list));
+
+    stats_update_sgwc_ues();
     
     return OGS_OK;
 }
@@ -891,17 +892,36 @@ sgwc_tunnel_t *sgwc_ul_tunnel_in_bearer(sgwc_bearer_t *bearer)
             OGS_GTP2_F_TEID_S1_U_SGW_GTP_U);
 }
 
-static void stats_write_list_sgwc_ues(void) {
+static void stats_add_sgwc_session(void)
+{
+    num_of_sgwc_sess = num_of_sgwc_sess + 1;
+    ogs_info("[Added] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
+
+    stats_update_sgwc_sessions();
+}
+
+static void stats_remove_sgwc_session(void)
+{
+    num_of_sgwc_sess = num_of_sgwc_sess - 1;
+    ogs_info("[Removed] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
+
+    stats_update_sgwc_sessions();
+}
+
+void stats_update_sgwc_ues(void)
+{
     sgwc_ue_t *sgwc_ue = NULL;
     char *buffer = NULL;
     char *ptr = NULL;
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    char num[20];
+    sprintf(num, "%d\n", ogs_list_count(&self.sgw_ue_list));
+    ogs_write_file_value("sgwc/num_ues", num);
 
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
         ptr += sprintf(ptr, "%s\n", sgwc_ue->imsi_bcd);
     }
-
     ogs_write_file_value("sgwc/list_ues", buffer);
     ogs_free(buffer);
 }
@@ -909,17 +929,19 @@ static void stats_write_list_sgwc_ues(void) {
 #define MAX_APN 63
 #define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
 
-static void stats_write_list_sgwc_sessions(void) {
+void stats_update_sgwc_sessions(void) {
     sgwc_ue_t *sgwc_ue = NULL;
     sgwc_sess_t *sess = NULL;
-
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    char num[20];
+    sprintf(num, "%d\n", num_of_sgwc_sess);
+    ogs_write_file_value("sgwc/num_sessions", num);
 
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
         ogs_list_for_each(&sgwc_ue->sess_list, sess) {
             ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s\n",
@@ -929,52 +951,7 @@ static void stats_write_list_sgwc_sessions(void) {
                 sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "");
         }
     }
-
     ogs_write_file_value("sgwc/list_sessions", buffer);
     ogs_free(buffer);
 }
 
-
-static void stats_add_sgwc_ue(void)
-{
-    num_of_sgwc_ue = num_of_sgwc_ue + 1;
-    ogs_info("[Added] Number of SGWC-UEs is now %d", num_of_sgwc_ue);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_sgwc_ue);
-    ogs_write_file_value("sgwc/num_ues", buffer);
-    stats_write_list_sgwc_ues();
-}
-
-static void stats_remove_sgwc_ue(void)
-{
-    num_of_sgwc_ue = num_of_sgwc_ue - 1;
-    ogs_info("[Removed] Number of SGWC-UEs is now %d", num_of_sgwc_ue);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_sgwc_ue);
-    ogs_write_file_value("sgwc/num_ues", buffer);
-    stats_write_list_sgwc_ues();
-}
-
-static void stats_add_sgwc_session(void)
-{
-    num_of_sgwc_sess = num_of_sgwc_sess + 1;
-    ogs_info("[Added] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_sgwc_sess);
-    ogs_write_file_value("sgwc/num_sessions", buffer);
-    stats_write_list_sgwc_sessions();
-}
-
-static void stats_remove_sgwc_session(void)
-{
-    num_of_sgwc_sess = num_of_sgwc_sess - 1;
-    ogs_info("[Removed] Number of SGWC-Sessions is now %d", num_of_sgwc_sess);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_sgwc_sess);
-    ogs_write_file_value("sgwc/num_sessions", buffer);
-    stats_write_list_sgwc_sessions();
-}

--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -194,6 +194,9 @@ sgwc_tunnel_t *sgwc_tunnel_find_by_pdr_id(
 sgwc_tunnel_t *sgwc_dl_tunnel_in_bearer(sgwc_bearer_t *bearer);
 sgwc_tunnel_t *sgwc_ul_tunnel_in_bearer(sgwc_bearer_t *bearer);
 
+void stats_update_sgwc_ues(void);
+void stats_update_sgwc_sessions(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sgwc/init.c
+++ b/src/sgwc/init.c
@@ -69,16 +69,8 @@ int sgwc_initialize()
 
     ogs_write_file_start("sgwc_start_time");
     ogs_write_file_subdir("sgwc");
-
-    char buffer[25];
-    sprintf(buffer, "%d\n", 0);
-    ogs_write_file_value("sgwc/num_sessions", buffer);
-    ogs_write_file_value("sgwc/num_ues", buffer);
-
-    sprintf(buffer, "List of Active Sessions\n");    
-    ogs_write_file_value("sgwc/list_sessions", buffer);
-    sprintf(buffer, "List of Attached UEs\n");
-    ogs_write_file_value("sgwc/list_ues", buffer);
+    stats_update_sgwc_ues();
+    stats_update_sgwc_sessions();
 
     return OGS_OK;
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -36,13 +36,10 @@ static OGS_POOL(smf_pf_pool, smf_pf_t);
 
 static int context_initialized = 0;
 
-static int num_of_smf_ue = 0;
 static int num_of_smf_sess = 0;
 
 static void stats_add_smf_session(void);
 static void stats_remove_smf_session(void);
-static void stats_add_smf_ue(void);
-static void stats_remove_smf_ue(void);
 
 int smf_ctf_config_init(smf_ctf_config_t *ctf_config)
 {
@@ -895,7 +892,7 @@ static smf_ue_t *smf_ue_add(void)
 
     ogs_list_add(&self.smf_ue_list, smf_ue);
 
-    stats_add_smf_ue();
+    stats_update_smf_ues();
     smf_metrics_inst_global_inc(SMF_METR_GLOB_GAUGE_UES_ACTIVE);
     ogs_info("[Added] Number of SMF-UEs is now %d",
             ogs_list_count(&self.smf_ue_list));
@@ -955,7 +952,7 @@ void smf_ue_remove(smf_ue_t *smf_ue)
 
     ogs_pool_free(&smf_ue_pool, smf_ue);
 
-    stats_remove_smf_ue();
+    stats_update_smf_ues();
     smf_metrics_inst_global_dec(SMF_METR_GLOB_GAUGE_UES_ACTIVE);
     ogs_info("[Removed] Number of SMF-UEs is now %d",
             ogs_list_count(&self.smf_ue_list));
@@ -1495,7 +1492,7 @@ uint8_t smf_sess_set_ue_ip(smf_sess_t *sess)
         ogs_assert_if_reached();
     }
 
-    stats_write_list_smf_sessions();
+    stats_update_smf_sessions();
 
     return cause_value;
 }
@@ -2976,17 +2973,38 @@ void smf_pf_precedence_pool_final(smf_sess_t *sess)
     ogs_index_final(&sess->pf_precedence_pool);
 }
 
-void stats_write_list_smf_ues(void) {
+static void stats_add_smf_session(void)
+{
+    smf_metrics_inst_global_inc(SMF_METR_GLOB_GAUGE_SESSIONS_ACTIVE);
+    num_of_smf_sess = num_of_smf_sess + 1;
+    ogs_info("[Added] Number of SMF-Sessions is now %d", num_of_smf_sess);
+
+    stats_update_smf_sessions();
+}
+
+static void stats_remove_smf_session(void)
+{
+    smf_metrics_inst_global_dec(SMF_METR_GLOB_GAUGE_SESSIONS_ACTIVE);
+    num_of_smf_sess = num_of_smf_sess - 1;
+    ogs_info("[Removed] Number of SMF-Sessions is now %d", num_of_smf_sess);
+
+    stats_update_smf_sessions();
+}
+
+void stats_update_smf_ues(void)
+{
     smf_ue_t *smf_ue = NULL;
     char *buffer = NULL;
     char *ptr = NULL;
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    char num[20];
+    sprintf(num, "%d\n", ogs_list_count(&self.smf_ue_list));
+    ogs_write_file_value("smf/num_ues", num);
 
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.smf_ue_list, smf_ue) {
         ptr += sprintf(ptr, "%s\n", smf_ue->imsi_bcd);
     }
-
     ogs_write_file_value("smf/list_ues", buffer);
     ogs_free(buffer);
 }
@@ -2994,17 +3012,19 @@ void stats_write_list_smf_ues(void) {
 #define MAX_APN 63
 #define MAX_SESSION_STRING_LEN (21 + OGS_MAX_IMSI_BCD_LEN + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN)
 
-void stats_write_list_smf_sessions(void) {
+void stats_update_smf_sessions(void) {
     smf_ue_t *smf_ue = NULL;
     smf_sess_t *sess = NULL;
-
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    char num[20];
+    sprintf(num, "%d\n", num_of_smf_sess);
+    ogs_write_file_value("smf/num_sessions", num);
 
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.smf_ue_list, smf_ue) {
         ogs_list_for_each(&smf_ue->sess_list, sess) {
             ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s\n",
@@ -3014,58 +3034,6 @@ void stats_write_list_smf_sessions(void) {
                 sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "");
         }
     }
-
     ogs_write_file_value("smf/list_sessions", buffer);
     ogs_free(buffer);
-}
-
-static void stats_add_smf_ue(void)
-{
-    num_of_smf_ue = num_of_smf_ue + 1;
-    ogs_info("[Added] Number of SMF-UEs is now %d", num_of_smf_ue);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_smf_ue);
-    ogs_write_file_value("smf/num_ues", buffer);
-
-    stats_write_list_smf_ues();
-}
-
-static void stats_remove_smf_ue(void)
-{
-    num_of_smf_ue = num_of_smf_ue - 1;
-    ogs_info("[Removed] Number of SMF-UEs is now %d", num_of_smf_ue);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_smf_ue);
-    ogs_write_file_value("smf/num_ues", buffer);
-
-    stats_write_list_smf_ues();
-}
-
-static void stats_add_smf_session(void)
-{
-    smf_metrics_inst_global_inc(SMF_METR_GLOB_GAUGE_SESSIONS_ACTIVE);
-    num_of_smf_sess = num_of_smf_sess + 1;
-    ogs_info("[Added] Number of SMF-Sessions is now %d", num_of_smf_sess);
-
-    char buffer[20];
-    sprintf(buffer, "%d\n", num_of_smf_sess);
-    ogs_write_file_value("smf/num_sessions", buffer);
-
-    stats_write_list_smf_sessions();
-}
-
-static void stats_remove_smf_session(void)
-{
-    char buffer[20];
-
-    smf_metrics_inst_global_dec(SMF_METR_GLOB_GAUGE_SESSIONS_ACTIVE);
-    num_of_smf_sess = num_of_smf_sess - 1;
-    ogs_info("[Removed] Number of SMF-Sessions is now %d", num_of_smf_sess);
-
-    sprintf(buffer, "%d\n", num_of_smf_sess);
-    ogs_write_file_value("smf/num_sessions", buffer);
-
-    stats_write_list_smf_sessions();
 }

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -930,6 +930,8 @@ smf_ue_t *smf_ue_add_by_imsi(uint8_t *imsi, int imsi_len)
     ogs_buffer_to_bcd(smf_ue->imsi, smf_ue->imsi_len, smf_ue->imsi_bcd);
     ogs_hash_set(self.imsi_hash, smf_ue->imsi, smf_ue->imsi_len, smf_ue);
 
+    stats_update_smf_ues();
+
     return smf_ue;
 }
 

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -509,8 +509,8 @@ void smf_pf_identifier_pool_final(smf_bearer_t *bearer);
 void smf_pf_precedence_pool_init(smf_sess_t *sess);
 void smf_pf_precedence_pool_final(smf_sess_t *sess);
 
-void stats_write_list_smf_ues(void);
-void stats_write_list_smf_sessions(void);
+void stats_update_smf_ues(void);
+void stats_update_smf_sessions(void);
 
 #ifdef __cplusplus
 }

--- a/src/smf/init.c
+++ b/src/smf/init.c
@@ -90,16 +90,8 @@ int smf_initialize()
 
     ogs_write_file_start("smf_start_time");
     ogs_write_file_subdir("smf");
-
-    char buffer[25];
-    sprintf(buffer, "%d\n", 0);
-    ogs_write_file_value("smf/num_sessions", buffer);
-    ogs_write_file_value("smf/num_ues", buffer);
-
-    sprintf(buffer, "List of Active Sessions\n");    
-    ogs_write_file_value("smf/list_sessions", buffer);
-    sprintf(buffer, "List of Attached UEs\n");
-    ogs_write_file_value("smf/list_ues", buffer);
+    stats_update_smf_ues();
+    stats_update_smf_sessions();
 
     return OGS_OK;
 }

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -268,7 +268,7 @@ uint8_t smf_s5c_handle_create_session_request(
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 
-   stats_write_list_smf_sessions();
+   stats_update_smf_sessions();
 
     /* Remove all previous bearer */
     smf_bearer_remove_all(sess);


### PR DESCRIPTION
Instead of maintaining separate functions for adding and removing, consolidated all stats reporting code into a single function that can be called idempotently since all it does is write out current values. This also greatly simplifies the difference between us and upstream. Already had written this code for the UPS, now just applying the same architectural design to CPS.