### PR TITLE
[pfcp] response_timeout should never call ogs_pfcp_xact_delete

### DIFF
--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -563,8 +563,6 @@ int ogs_pfcp_xact_commit(ogs_pfcp_xact_t *xact)
 
     if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
         ogs_error("ogs_pfcp_sendto() failed");
-        ogs_pfcp_xact_delete(xact);
-        return OGS_ERROR;
     }
 
     return OGS_OK;

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -607,7 +607,7 @@ static void response_timeout(void *data)
 
         if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
             ogs_error("ogs_pfcp_sendto() failed");
-            goto out;
+            // goto out;
         }
     } else {
         ogs_warn("[%d] %s No Reponse. Give up! "

--- a/lib/pfcp/xact.c
+++ b/lib/pfcp/xact.c
@@ -607,7 +607,6 @@ static void response_timeout(void *data)
 
         if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) {
             ogs_error("ogs_pfcp_sendto() failed");
-            // goto out;
         }
     } else {
         ogs_warn("[%d] %s No Reponse. Give up! "
@@ -626,7 +625,6 @@ static void response_timeout(void *data)
 
     return;
 
-out:
     ogs_pfcp_xact_delete(xact);
 }
 


### PR DESCRIPTION
The if (ogs_pfcp_sendto(xact->node, pkbuf) != OGS_OK) line will executed if the sending node encounters any sort of socket/sendto errors. In this case, jumping to out and calling pfcp_xact_delete() without any new timers set will essentially "deadlock" this side of the connection into radio silence. If we just log the error and return, the error is picked up and handled by the calling function, the next timer gets set, and code proceeds as normal.

Socket errors are uncommon over localhost but this problem is actually big for our deployment context because our routers will often hit very temporary/intermittent socket errors if the VPN they're using to communicate stumbles or isn't yet online.