### PR TITLE
add PFCP information to /tmp/open5gs

### DIFF
--- a/src/sgwc/init.c
+++ b/src/sgwc/init.c
@@ -69,6 +69,7 @@ int sgwc_initialize()
 
     ogs_write_file_start("sgwc_start_time");
     ogs_write_file_subdir("sgwc");
+    stats_update_sgwc_pfcp_nodes();
     stats_update_sgwc_ues();
     stats_update_sgwc_sessions();
 

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -180,12 +180,17 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
         }
         node->already_associated = true;
 
+        stats_update_sgwc_pfcp_nodes();
+
         break;
     case OGS_FSM_EXIT_SIG:
         ogs_info("PFCP de-associated [%s]:%d",
             OGS_ADDR(&node->addr, buf),
             OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
+
+        stats_update_sgwc_pfcp_nodes();
+
         break;
     case SGWC_EVT_SXA_MESSAGE:
         message = e->pfcp_message;
@@ -363,4 +368,39 @@ static void node_timeout(ogs_pfcp_xact_t *xact, void *data)
         ogs_error("Not implemented [type:%d]", type);
         break;
     }
+}
+
+#define MAX_PFCP_STRING_LEN 9 + INET_ADDRSTRLEN + (4 * OGS_MAX_NUM_OF_TAI)
+
+void stats_update_sgwc_pfcp_nodes(void) {
+    ogs_pfcp_node_t *node = NULL;
+    char buf[OGS_ADDRSTRLEN];
+    int i;
+
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    int num_pfcp = 0;
+
+    ptr = buffer = ogs_calloc(MAX_PFCP_STRING_LEN * OGS_MAX_NUM_OF_SERVED_TAI, 1);
+    ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, node) {
+        if (node->sm.state == (ogs_fsm_handler_t) &sgwc_pfcp_state_associated) {
+            num_pfcp++;
+            ptr += sprintf(ptr, "ip:%s tac:", OGS_ADDR(&node->addr, buf));
+            for(i = 0; i < node->num_of_tac; i++) {
+                ptr += sprintf(ptr, "%u,",node->tac[i]);
+            }
+            if (node->num_of_tac > 0) {
+                ptr--;
+            }
+            ptr += sprintf(ptr, "\n");
+        }
+    }
+
+    char num[20];
+    sprintf(num, "%d\n", num_pfcp);
+    ogs_write_file_value("sgwc/num_pfcp", num);
+
+    ogs_write_file_value("sgwc/list_pfcp", buffer);
+    ogs_free(buffer);
 }

--- a/src/sgwc/sgwc-sm.h
+++ b/src/sgwc/sgwc-sm.h
@@ -37,6 +37,8 @@ void sgwc_pfcp_state_will_associate(ogs_fsm_t *s, sgwc_event_t *e);
 void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e);
 void sgwc_pfcp_state_exception(ogs_fsm_t *s, sgwc_event_t *e);
 
+void stats_update_sgwc_pfcp_nodes(void);
+
 #define sgwc_sm_debug(__pe) \
     ogs_debug("%s(): %s\n", __func__, sgwc_event_get_name(__pe))
 

--- a/src/sgwu/init.c
+++ b/src/sgwu/init.c
@@ -66,6 +66,7 @@ int sgwu_initialize()
 
     ogs_write_file_start("sgwu_start_time");
     ogs_write_file_subdir("sgwu");
+    stats_update_sgwu_pfcp_nodes();
     stats_update_sgwu_sessions();
     
     return OGS_OK;

--- a/src/sgwu/pfcp-sm.c
+++ b/src/sgwu/pfcp-sm.c
@@ -170,12 +170,18 @@ void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e)
             OGS_PORT(&node->addr));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
+
+        stats_update_sgwu_pfcp_nodes();
+
         break;
     case OGS_FSM_EXIT_SIG:
         ogs_info("PFCP de-associated [%s]:%d",
             OGS_ADDR(&node->addr, buf),
             OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
+
+        stats_update_sgwu_pfcp_nodes();
+
         break;
     case SGWU_EVT_SXA_MESSAGE:
         message = e->pfcp_message;
@@ -317,4 +323,39 @@ static void node_timeout(ogs_pfcp_xact_t *xact, void *data)
         ogs_error("Not implemented [type:%d]", type);
         break;
     }
+}
+
+#define MAX_PFCP_STRING_LEN 9 + INET_ADDRSTRLEN + (4 * OGS_MAX_NUM_OF_TAI)
+
+void stats_update_sgwu_pfcp_nodes(void) {
+    ogs_pfcp_node_t *node = NULL;
+    char buf[OGS_ADDRSTRLEN];
+    int i;
+
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    int num_pfcp = 0;
+
+    ptr = buffer = ogs_calloc(MAX_PFCP_STRING_LEN * OGS_MAX_NUM_OF_SERVED_TAI, 1);
+    ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, node) {
+        if (node->sm.state == (ogs_fsm_handler_t) &sgwu_pfcp_state_associated) {
+            num_pfcp++;
+            ptr += sprintf(ptr, "ip:%s tac:", OGS_ADDR(&node->addr, buf));
+            for(i = 0; i < node->num_of_tac; i++) {
+                ptr += sprintf(ptr, "%u,",node->tac[i]);
+            }
+            if (node->num_of_tac > 0) {
+                ptr--;
+            }
+            ptr += sprintf(ptr, "\n");
+        }
+    }
+
+    char num[20];
+    sprintf(num, "%d\n", num_pfcp);
+    ogs_write_file_value("sgwu/num_pfcp", num);
+
+    ogs_write_file_value("sgwu/list_pfcp", buffer);
+    ogs_free(buffer);
 }

--- a/src/sgwu/sgwu-sm.h
+++ b/src/sgwu/sgwu-sm.h
@@ -37,6 +37,8 @@ void sgwu_pfcp_state_will_associate(ogs_fsm_t *s, sgwu_event_t *e);
 void sgwu_pfcp_state_associated(ogs_fsm_t *s, sgwu_event_t *e);
 void sgwu_pfcp_state_exception(ogs_fsm_t *s, sgwu_event_t *e);
 
+void stats_update_sgwu_pfcp_nodes(void);
+
 #define sgwu_sm_debug(__pe) \
     ogs_debug("%s(): %s\n", __func__, sgwu_event_get_name(__pe))
 

--- a/src/smf/init.c
+++ b/src/smf/init.c
@@ -83,6 +83,7 @@ int smf_initialize()
 
     ogs_write_file_start("smf_start_time");
     ogs_write_file_subdir("smf");
+    stats_update_smf_pfcp_nodes();
     stats_update_smf_ues();
     stats_update_smf_sessions();
 

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -182,12 +182,17 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
         }
         node->already_associated = true;
 
+        stats_update_smf_pfcp_nodes();
+
         break;
     case OGS_FSM_EXIT_SIG:
         ogs_info("PFCP de-associated [%s]:%d",
             OGS_ADDR(&node->addr, buf),
             OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
+
+        stats_update_smf_pfcp_nodes();
+        
         break;
     case SMF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
@@ -379,4 +384,36 @@ static void node_timeout(ogs_pfcp_xact_t *xact, void *data)
         ogs_error("Not implemented [type:%d]", type);
         break;
     }
+}
+
+#define MAX_PFCP_STRING_LEN 9 + INET_ADDRSTRLEN + (4 * OGS_MAX_NUM_OF_TAI)
+
+void stats_update_smf_pfcp_nodes(void) {
+    ogs_pfcp_node_t *node = NULL;
+    char buf[OGS_ADDRSTRLEN];
+    int i;
+
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    int num_pfcp = 0;
+
+    ptr = buffer = ogs_malloc(MAX_PFCP_STRING_LEN * OGS_MAX_NUM_OF_SERVED_TAI);
+    ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, node) {
+        if (node->sm.state == (ogs_fsm_handler_t) &smf_pfcp_state_associated) {
+            num_pfcp++;
+            ptr += sprintf(ptr, "ip:%s tac:", OGS_ADDR(&node->addr, buf));
+            for(i = 0; i < node->num_of_tac; i++) {
+                ptr += sprintf(ptr, ",%u",node->tac[i]);
+            }
+            ptr += sprintf(ptr, "\n");
+        }
+    }
+
+    char num[20];
+    sprintf(num, "%d\n", num_pfcp);
+    ogs_write_file_value("smf/num_pfcp", num);
+
+    ogs_write_file_value("smf/list_pfcp", buffer);
+    ogs_free(buffer);
 }

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -192,7 +192,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
         ogs_timer_stop(node->t_no_heartbeat);
 
         stats_update_smf_pfcp_nodes();
-        
+
         break;
     case SMF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
@@ -404,7 +404,10 @@ void stats_update_smf_pfcp_nodes(void) {
             num_pfcp++;
             ptr += sprintf(ptr, "ip:%s tac:", OGS_ADDR(&node->addr, buf));
             for(i = 0; i < node->num_of_tac; i++) {
-                ptr += sprintf(ptr, ",%u",node->tac[i]);
+                ptr += sprintf(ptr, "%u,",node->tac[i]);
+            }
+            if (node->num_of_tac > 0) {
+                ptr--;
             }
             ptr += sprintf(ptr, "\n");
         }

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -398,7 +398,7 @@ void stats_update_smf_pfcp_nodes(void) {
 
     int num_pfcp = 0;
 
-    ptr = buffer = ogs_malloc(MAX_PFCP_STRING_LEN * OGS_MAX_NUM_OF_SERVED_TAI);
+    ptr = buffer = ogs_calloc(MAX_PFCP_STRING_LEN * OGS_MAX_NUM_OF_SERVED_TAI, 1);
     ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, node) {
         if (node->sm.state == (ogs_fsm_handler_t) &smf_pfcp_state_associated) {
             num_pfcp++;

--- a/src/smf/smf-sm.h
+++ b/src/smf/smf-sm.h
@@ -59,6 +59,8 @@ void smf_pfcp_state_will_associate(ogs_fsm_t *s, smf_event_t *e);
 void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e);
 void smf_pfcp_state_exception(ogs_fsm_t *s, smf_event_t *e);
 
+void stats_update_smf_pfcp_nodes(void);
+
 #define smf_sm_debug(__pe) \
     ogs_debug("%s(): %s", __func__, smf_event_get_name(__pe))
 

--- a/src/upf/init.c
+++ b/src/upf/init.c
@@ -69,6 +69,7 @@ int upf_initialize()
 
     ogs_write_file_start("upf_start_time");
     ogs_write_file_subdir("upf");
+    stats_update_upf_pfcp_nodes();
     stats_update_upf_sessions();
 
     return OGS_OK;

--- a/src/upf/pfcp-sm.c
+++ b/src/upf/pfcp-sm.c
@@ -175,12 +175,18 @@ void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e)
             OGS_PORT(&node->addr));
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
+
+        stats_update_upf_pfcp_nodes();
+
         break;
     case OGS_FSM_EXIT_SIG:
         ogs_info("PFCP de-associated [%s]:%d",
             OGS_ADDR(&node->addr, buf),
             OGS_PORT(&node->addr));
         ogs_timer_stop(node->t_no_heartbeat);
+
+        stats_update_upf_pfcp_nodes();
+
         break;
     case UPF_EVT_N4_MESSAGE:
         message = e->pfcp_message;
@@ -322,4 +328,39 @@ static void node_timeout(ogs_pfcp_xact_t *xact, void *data)
         ogs_error("Not implemented [type:%d]", type);
         break;
     }
+}
+
+#define MAX_PFCP_STRING_LEN 9 + INET_ADDRSTRLEN + (4 * OGS_MAX_NUM_OF_TAI)
+
+void stats_update_upf_pfcp_nodes(void) {
+    ogs_pfcp_node_t *node = NULL;
+    char buf[OGS_ADDRSTRLEN];
+    int i;
+
+    char *buffer = NULL;
+    char *ptr = NULL;
+
+    int num_pfcp = 0;
+
+    ptr = buffer = ogs_calloc(MAX_PFCP_STRING_LEN * OGS_MAX_NUM_OF_SERVED_TAI, 1);
+    ogs_list_for_each(&ogs_pfcp_self()->pfcp_peer_list, node) {
+        if (node->sm.state == (ogs_fsm_handler_t) &upf_pfcp_state_associated) {
+            num_pfcp++;
+            ptr += sprintf(ptr, "ip:%s tac:", OGS_ADDR(&node->addr, buf));
+            for(i = 0; i < node->num_of_tac; i++) {
+                ptr += sprintf(ptr, "%u,",node->tac[i]);
+            }
+            if (node->num_of_tac > 0) {
+                ptr--;
+            }
+            ptr += sprintf(ptr, "\n");
+        }
+    }
+
+    char num[20];
+    sprintf(num, "%d\n", num_pfcp);
+    ogs_write_file_value("upf/num_pfcp", num);
+
+    ogs_write_file_value("upf/list_pfcp", buffer);
+    ogs_free(buffer);
 }

--- a/src/upf/upf-sm.h
+++ b/src/upf/upf-sm.h
@@ -37,6 +37,8 @@ void upf_pfcp_state_will_associate(ogs_fsm_t *s, upf_event_t *e);
 void upf_pfcp_state_associated(ogs_fsm_t *s, upf_event_t *e);
 void upf_pfcp_state_exception(ogs_fsm_t *s, upf_event_t *e);
 
+void stats_update_upf_pfcp_nodes(void);
+
 #define upf_sm_debug(__pe) \
     ogs_debug("%s(): %s", __func__, upf_event_get_name(__pe))
 


### PR DESCRIPTION
This PR adds pfcp node association information (who's associated, their IP address, and TAC if exists) to smf, upf, sgwc, and sgwu.