### PR TITLE
add SEID information to CPS printouts

### DIFF
--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -924,11 +924,12 @@ void stats_update_sgwc_sessions(void) {
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
         ogs_list_for_each(&sgwc_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s\n",
+            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s seid_local:0x%lx seid_peer:0x%lx\n",
                 sgwc_ue->imsi_bcd,
                 sess->session.name ? sess->session.name : "",
                 sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(&sess->session.ue_ip.addr, buf1) : "",
-                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "");
+                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "",
+                (long)sess->sgwc_sxa_seid, (long)sess->sgwu_sxa_seid);
         }
     }
     ogs_write_file_value("sgwc/list_sessions", buffer);

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2925,11 +2925,12 @@ void stats_update_smf_sessions(void) {
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.smf_ue_list, smf_ue) {
         ogs_list_for_each(&smf_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s\n",
+            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s seid_local:0x%lx seid_peer:0x%lx\n",
                 smf_ue->imsi_bcd,
                 sess->session.name ? sess->session.name : "",
                 sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(&sess->session.ue_ip.addr, buf1) : "",
-                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "");
+                sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "",
+                (long)sess->smf_n4_seid, (long)sess->upf_n4_seid);
         }
     }
     ogs_write_file_value("smf/list_sessions", buffer);


### PR DESCRIPTION
Adding SEID information (local and remote) to /tmp/open5gs for CPS. This will help debug any further sync issues that occur.