### PR TITLE
printout ups variables

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3561,8 +3561,8 @@ void stats_update_mme_ues(void)
 
     ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
-        ptr += sprintf(ptr, "imsi:%s enb:%s\n",
-            mme_ue->imsi_bcd, OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1));
+        ptr += sprintf(ptr, "imsi:%s enb:%s\n", mme_ue->imsi_bcd,
+            mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "");
     }
     ogs_write_file_value("mme/list_ues", buffer);
     ogs_free(buffer);
@@ -3590,8 +3590,8 @@ void stats_update_mme_sessions(void)
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ogs_list_for_each(&mme_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s enb:%s",
-                mme_ue->imsi_bcd, OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1));
+            ptr += sprintf(ptr, "imsi:%s enb:%s", mme_ue->imsi_bcd,
+                mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "");
             if (sess->session) {
                 session = sess->session;
                 ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3561,8 +3561,9 @@ void stats_update_mme_ues(void)
 
     ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
-        ptr += sprintf(ptr, "imsi:%s enb:%s\n", mme_ue->imsi_bcd,
-            mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "");
+        ptr += sprintf(ptr, "imsi:%s enb:%s tac:%d\n", mme_ue->imsi_bcd,
+            mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "",
+            mme_ue->tai.tac);
     }
     ogs_write_file_value("mme/list_ues", buffer);
     ogs_free(buffer);
@@ -3590,8 +3591,9 @@ void stats_update_mme_sessions(void)
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ogs_list_for_each(&mme_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s enb:%s ", mme_ue->imsi_bcd,
-                mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "");
+            ptr += sprintf(ptr, "imsi:%s enb:%s tac:%d ", mme_ue->imsi_bcd,
+                mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "", 
+                mme_ue->tai.tac);
             if (sess->session) {
                 session = sess->session;
                 ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3590,7 +3590,7 @@ void stats_update_mme_sessions(void)
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ogs_list_for_each(&mme_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s enb:%s", mme_ue->imsi_bcd,
+            ptr += sprintf(ptr, "imsi:%s enb:%s ", mme_ue->imsi_bcd,
                 mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "");
             if (sess->session) {
                 session = sess->session;

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3551,6 +3551,7 @@ void stats_update_mme_enbs(void)
 void stats_update_mme_ues(void)
 {
     mme_ue_t *mme_ue = NULL;
+    char buf1[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
@@ -3560,7 +3561,8 @@ void stats_update_mme_ues(void)
 
     ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
-        ptr += sprintf(ptr, "%s\n", mme_ue->imsi_bcd);
+        ptr += sprintf(ptr, "imsi:%s enb:%s\n",
+            mme_ue->imsi_bcd, OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1));
     }
     ogs_write_file_value("mme/list_ues", buffer);
     ogs_free(buffer);
@@ -3577,6 +3579,7 @@ void stats_update_mme_sessions(void)
 
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
+    char buf3[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
@@ -3587,13 +3590,14 @@ void stats_update_mme_sessions(void)
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ogs_list_for_each(&mme_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s ", mme_ue->imsi_bcd);
+            ptr += sprintf(ptr, "imsi:%s enb:%s",
+                mme_ue->imsi_bcd, OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1));
             if (sess->session) {
                 session = sess->session;
                 ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s\n",
                     session->name ? session->name : "",
-                    session->ue_ip.ipv4 ? OGS_INET_NTOP(session->ue_ip.addr, buf1) : "",
-                    session->ue_ip.ipv6 ? OGS_INET6_NTOP(session->ue_ip.addr6, buf2) : "");
+                    session->ue_ip.ipv4 ? OGS_INET_NTOP(session->ue_ip.addr, buf2) : "",
+                    session->ue_ip.ipv6 ? OGS_INET6_NTOP(session->ue_ip.addr6, buf3) : "");
             } else {
                 ptr += sprintf(ptr, "apn: ip4: ip6:\n");
             }

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -914,6 +914,7 @@ void stats_update_sgwc_sessions(void) {
     sgwc_sess_t *sess = NULL;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
+    char buf3[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
@@ -924,11 +925,12 @@ void stats_update_sgwc_sessions(void) {
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
         ogs_list_for_each(&sgwc_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s seid_cp:0x%lx seid_up:0x%lx\n",
+            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s sgwu:%s seid_cp:0x%lx seid_up:0x%lx\n",
                 sgwc_ue->imsi_bcd,
                 sess->session.name ? sess->session.name : "",
                 sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(&sess->session.ue_ip.addr, buf1) : "",
                 sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "",
+                sess->pfcp_node ? OGS_ADDR(&sess->pfcp_node->addr, buf3) : "",
                 (long)sess->sgwc_sxa_seid, (long)sess->sgwu_sxa_seid);
         }
     }

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -139,6 +139,8 @@ static void sgwc_sxa_handle_session_reestablishment(
     ogs_assert(up_f_seid);
     sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
 
+    stats_update_sgwc_sessions();
+
     return;
 }
 
@@ -331,6 +333,8 @@ void sgwc_sxa_handle_session_establishment_response(
     up_f_seid = pfcp_rsp->up_f_seid.data;
     ogs_assert(up_f_seid);
     sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
+
+    stats_update_sgwc_sessions();
 
     pgw_s5c_teid = create_session_request->
         pgw_s5_s8_address_for_control_plane_or_pmip.data;

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -280,17 +280,28 @@ void stats_update_sgwu_sessions(void)
     ogs_free(buffer);
 
     ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
-        ptr += sprintf(ptr, "ip:%s addr:%s \n", 
-            OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
+    ogs_list_for_each(&self.sess_list, sess) {
+        ogs_list_for_each(&sess->pfcp.far_list, far) {
+            ptr += sprintf(ptr, "act:%u, dest:%u, outer_header_creation:%s\n",
+                far->apply_action, far->dst_if,
+                OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+        }
     }
-    ogs_write_file_value("sgwu/gtpu_peers", buffer);
+    ogs_write_file_value("sgwu/fars", buffer);
     ogs_free(buffer);
 
-    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
-        ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
-    }
-    ogs_write_file_value("sgwu/gtpu_resources", buffer);
-    ogs_free(buffer);
+    // ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    // ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
+    //     ptr += sprintf(ptr, "ip:%s addr:%s \n", 
+    //         OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
+    // }
+    // ogs_write_file_value("sgwu/gtpu_peers", buffer);
+    // ogs_free(buffer);
+
+    // ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    // ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
+    //     ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
+    // }
+    // ogs_write_file_value("sgwu/gtpu_resources", buffer);
+    // ogs_free(buffer);
 }

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -260,6 +260,10 @@ sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)
 void stats_update_sgwu_sessions(void)
 {
     sgwu_sess_t *sess = NULL;
+    ogs_gtp_node_t *peer;
+    ogs_gtpu_resource_t *resource;
+    char buf1[OGS_ADDRSTRLEN];
+    char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
@@ -273,5 +277,20 @@ void stats_update_sgwu_sessions(void)
             (long)sess->sgwc_sxa_f_seid.seid, (long)sess->sgwu_sxa_seid);
     }
     ogs_write_file_value("sgwu/list_sessions", buffer);
+    ogs_free(buffer);
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
+        ptr += sprintf(ptr, "ip:%s addr:%s \n", 
+            OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
+    }
+    ogs_write_file_value("sgwu/gtpu_peers", buffer);
+    ogs_free(buffer);
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
+        ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
+    }
+    ogs_write_file_value("sgwu/gtpu_resources", buffer);
     ogs_free(buffer);
 }

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -261,17 +261,13 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
 
     buf += sprintf(buf, "\tfar ");
-    switch (far->apply_action) {
-    case OGS_PFCP_APPLY_ACTION_DROP:
+    if (far->apply_action & OGS_PFCP_APPLY_ACTION_DROP) {
         buf += sprintf(buf, "act:DROP ");
-        break;
-    case OGS_PFCP_APPLY_ACTION_FORW:
+    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_FORW) {
         buf += sprintf(buf, "act:FORW ");
-        break;
-    case OGS_PFCP_APPLY_ACTION_BUFF:
+    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_BUFF) {
         buf += sprintf(buf, "act:BUFF ");
-        break;
-    default:
+    } else {
         buf += sprintf(buf, "act:%u ", far->apply_action);
     }
 
@@ -312,6 +308,7 @@ void stats_update_sgwu_sessions(void)
     ogs_list_for_each(&self.sess_list, sess) {
         ptr += sprintf(ptr, "seid_cp:0x%lx seid_up:0x%lx\n",
             (long)sess->sgwc_sxa_f_seid.seid, (long)sess->sgwu_sxa_seid);
+
         ogs_list_for_each(&sess->pfcp.far_list, far) {
             ptr = print_far(ptr, far);
         }

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -257,7 +257,7 @@ sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)
 
 #define MAX_SESSION_STRING_LEN (22 + 16 + 16)
 
-static void print_far(char *buf, ogs_pfcp_far_t *far) {
+static char *print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
 
     buf += sprintf(buf, "\tfar ");
@@ -294,7 +294,7 @@ static void print_far(char *buf, ogs_pfcp_far_t *far) {
     }
 
     buf += sprintf(buf, "\n");
-    return;
+    return buf;
 }
 
 void stats_update_sgwu_sessions(void)
@@ -313,7 +313,7 @@ void stats_update_sgwu_sessions(void)
         ptr += sprintf(ptr, "seid_cp:0x%lx seid_up:0x%lx\n",
             (long)sess->sgwc_sxa_f_seid.seid, (long)sess->sgwu_sxa_seid);
         ogs_list_for_each(&sess->pfcp.far_list, far) {
-            print_far(ptr, far);
+            ptr = print_far(ptr, far);
         }
     }
     ogs_write_file_value("sgwu/list_sessions", buffer);

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -271,7 +271,7 @@ void stats_update_sgwu_sessions(void)
     sprintf(num, "%d\n", ogs_list_count(&self.sess_list));
     ogs_write_file_value("sgwu/num_sessions", num);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sess_list, sess) {
         ptr += sprintf(ptr, "seid_cp:0x%lx seid_up:0x%lx\n",
             (long)sess->sgwc_sxa_f_seid.seid, (long)sess->sgwu_sxa_seid);
@@ -279,7 +279,7 @@ void stats_update_sgwu_sessions(void)
     ogs_write_file_value("sgwu/list_sessions", buffer);
     ogs_free(buffer);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
         ptr += sprintf(ptr, "ip:%s addr:%s \n", 
             OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
@@ -287,7 +287,7 @@ void stats_update_sgwu_sessions(void)
     ogs_write_file_value("sgwu/gtpu_peers", buffer);
     ogs_free(buffer);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
         ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
     }

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -262,6 +262,7 @@ void stats_update_sgwu_sessions(void)
     sgwu_sess_t *sess = NULL;
     ogs_gtp_node_t *peer;
     ogs_gtpu_resource_t *resource;
+    ogs_pfcp_far_t *far;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2915,6 +2915,7 @@ void stats_update_smf_sessions(void) {
     smf_sess_t *sess = NULL;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
+    char buf3[OGS_ADDRSTRLEN];
     char *buffer = NULL;
     char *ptr = NULL;
 
@@ -2925,11 +2926,12 @@ void stats_update_smf_sessions(void) {
     ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.smf_ue_list, smf_ue) {
         ogs_list_for_each(&smf_ue->sess_list, sess) {
-            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s seid_cp:0x%lx seid_up:0x%lx\n",
+            ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s upf:%s seid_cp:0x%lx seid_up:0x%lx\n",
                 smf_ue->imsi_bcd,
                 sess->session.name ? sess->session.name : "",
                 sess->session.ue_ip.ipv4 ? OGS_INET_NTOP(&sess->session.ue_ip.addr, buf1) : "",
                 sess->session.ue_ip.ipv6 ? OGS_INET6_NTOP(&sess->session.ue_ip.addr6, buf2) : "",
+                sess->pfcp_node ? OGS_ADDR(&sess->pfcp_node->addr, buf3) : "",
                 (long)sess->smf_n4_seid, (long)sess->upf_n4_seid);
         }
     }

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -239,6 +239,8 @@ uint8_t smf_5gc_n4_handle_session_establishment_response(
     ogs_assert(up_f_seid);
     sess->upf_n4_seid = be64toh(up_f_seid->seid);
 
+    stats_update_smf_sessions();
+
     return OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 }
 
@@ -776,6 +778,9 @@ uint8_t smf_epc_n4_handle_session_establishment_response(
     up_f_seid = rsp->up_f_seid.data;
     ogs_assert(up_f_seid);
     sess->upf_n4_seid = be64toh(up_f_seid->seid);
+
+    stats_update_smf_sessions();
+
     return OGS_PFCP_CAUSE_REQUEST_ACCEPTED;
 }
 

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -546,11 +546,49 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 #define MAX_APN 63
 #define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16)
 
+static void print_far(char *buf, ogs_pfcp_far_t *far) {
+    char buf1[OGS_ADDRSTRLEN];
+
+    buf += sprintf(buf, "\tfar ");
+    switch (far->apply_action) {
+    case OGS_PFCP_APPLY_ACTION_DROP:
+        buf += sprintf(buf, "act:DROP ");
+        break;
+    case OGS_PFCP_APPLY_ACTION_FORW:
+        buf += sprintf(buf, "act:FORW ");
+        break;
+    case OGS_PFCP_APPLY_ACTION_BUFF:
+        buf += sprintf(buf, "act:BUFF ");
+        break;
+    default:
+        buf += sprintf(buf, "act:%u ", far->apply_action);
+    }
+
+    switch (far->dst_if) {
+    case OGS_PFCP_INTERFACE_ACCESS:
+        buf += sprintf(buf, "dst:ACCESS ");
+        break;
+    case OGS_PFCP_INTERFACE_CORE:
+        buf += sprintf(buf, "dst:CORE ");
+        break;
+    case OGS_PFCP_INTERFACE_CP_FUNCTION:
+        buf += sprintf(buf, "dst:CP ");
+        break;
+    default:
+        buf += sprintf(buf, "dst:%u ", far->dst_if);
+    }
+
+    if (far->outer_header_creation.addr) {
+        buf += sprintf(buf, "hdr:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+    }
+
+    buf += sprintf(buf, "\n");
+    return;
+}
+
 void stats_update_upf_sessions(void)
 {
     upf_sess_t *sess = NULL;
-    ogs_gtp_node_t *peer;
-    ogs_gtpu_resource_t *resource;
     ogs_pfcp_far_t *far;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
@@ -568,33 +606,10 @@ void stats_update_upf_sessions(void)
             sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
             sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "",
             (long)sess->smf_n4_f_seid.seid, (long)sess->upf_n4_seid);
+        ogs_list_for_each(&sess->pfcp.far_list, far) {
+            print_far(ptr, far);
+        }
     }
     ogs_write_file_value("upf/list_sessions", buffer);
     ogs_free(buffer);
-
-    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    ogs_list_for_each(&self.sess_list, sess) {
-        ogs_list_for_each(&sess->pfcp.far_list, far) {
-            ptr += sprintf(ptr, "act:%u, dest:%u, outer_header_creation:%s\n",
-                far->apply_action, far->dst_if,
-                OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
-        }
-    }
-    ogs_write_file_value("upf/fars", buffer);
-    ogs_free(buffer);
-
-    // ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    // ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
-    //     ptr += sprintf(ptr, "ip:%s addr:%s \n", 
-    //         OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
-    // }
-    // ogs_write_file_value("upf/gtpu_peers", buffer);
-    // ogs_free(buffer);
-
-    // ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    // ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
-    //     ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
-    // }
-    // ogs_write_file_value("upf/gtpu_resources", buffer);
-    // ogs_free(buffer);
 }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -549,6 +549,8 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 void stats_update_upf_sessions(void)
 {
     upf_sess_t *sess = NULL;
+    ogs_gtp_node_t *peer;
+    ogs_gtpu_resource_t *resource;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;
@@ -567,5 +569,20 @@ void stats_update_upf_sessions(void)
             (long)sess->smf_n4_f_seid.seid, (long)sess->upf_n4_seid);
     }
     ogs_write_file_value("upf/list_sessions", buffer);
+    ogs_free(buffer);
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
+        ptr += sprintf(ptr, "ip:%s addr:%s \n", 
+            OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
+    }
+    ogs_write_file_value("upf/gtpu_peers", buffer);
+    ogs_free(buffer);
+
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
+        ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
+    }
+    ogs_write_file_value("upf/gtpu_resources", buffer);
     ogs_free(buffer);
 }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -550,17 +550,13 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
 
     buf += sprintf(buf, "\tfar ");
-    switch (far->apply_action) {
-    case OGS_PFCP_APPLY_ACTION_DROP:
+    if (far->apply_action & OGS_PFCP_APPLY_ACTION_DROP) {
         buf += sprintf(buf, "act:DROP ");
-        break;
-    case OGS_PFCP_APPLY_ACTION_FORW:
+    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_FORW) {
         buf += sprintf(buf, "act:FORW ");
-        break;
-    case OGS_PFCP_APPLY_ACTION_BUFF:
+    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_BUFF) {
         buf += sprintf(buf, "act:BUFF ");
-        break;
-    default:
+    } else {
         buf += sprintf(buf, "act:%u ", far->apply_action);
     }
 
@@ -606,6 +602,7 @@ void stats_update_upf_sessions(void)
             sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
             sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "",
             (long)sess->smf_n4_f_seid.seid, (long)sess->upf_n4_seid);
+        
         ogs_list_for_each(&sess->pfcp.far_list, far) {
             ptr = print_far(ptr, far);
         }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -551,6 +551,7 @@ void stats_update_upf_sessions(void)
     upf_sess_t *sess = NULL;
     ogs_gtp_node_t *peer;
     ogs_gtpu_resource_t *resource;
+    ogs_pfcp_far_t *far;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;
@@ -572,17 +573,28 @@ void stats_update_upf_sessions(void)
     ogs_free(buffer);
 
     ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
-        ptr += sprintf(ptr, "ip:%s addr:%s \n", 
-            OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
+    ogs_list_for_each(&self.sess_list, sess) {
+        ogs_list_for_each(&sess->pfcp.far_list, far) {
+            ptr += sprintf(ptr, "act:%u, dest:%u, outer_header_creation:%s\n",
+                far->apply_action, far->dst_if,
+                OGS_INET_NTOP(far->outer_header_creation.addr, buf1));
+        }
     }
-    ogs_write_file_value("upf/gtpu_peers", buffer);
+    ogs_write_file_value("upf/fars", buffer);
     ogs_free(buffer);
 
-    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
-    ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
-        ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
-    }
-    ogs_write_file_value("upf/gtpu_resources", buffer);
-    ogs_free(buffer);
+    // ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    // ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
+    //     ptr += sprintf(ptr, "ip:%s addr:%s \n", 
+    //         OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
+    // }
+    // ogs_write_file_value("upf/gtpu_peers", buffer);
+    // ogs_free(buffer);
+
+    // ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    // ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
+    //     ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
+    // }
+    // ogs_write_file_value("upf/gtpu_resources", buffer);
+    // ogs_free(buffer);
 }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -560,7 +560,7 @@ void stats_update_upf_sessions(void)
     sprintf(num, "%d\n", ogs_list_count(&self.sess_list));
     ogs_write_file_value("upf/num_sessions", num);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&self.sess_list, sess) {
         ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s seid_cp:0x%lx seid_up:0x%lx\n",
             sess->dnn ? sess->dnn : "",
@@ -571,7 +571,7 @@ void stats_update_upf_sessions(void)
     ogs_write_file_value("upf/list_sessions", buffer);
     ogs_free(buffer);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&ogs_gtp_self()->gtpu_peer_list, peer) {
         ptr += sprintf(ptr, "ip:%s addr:%s \n", 
             OGS_INET_NTOP(&peer->ip, buf1), OGS_ADDR(&peer->addr, buf2));
@@ -579,7 +579,7 @@ void stats_update_upf_sessions(void)
     ogs_write_file_value("upf/gtpu_peers", buffer);
     ogs_free(buffer);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
     ogs_list_for_each(&ogs_gtp_self()->gtpu_resource_list, resource) {
         ptr += sprintf(ptr, "ip:%s \n", OGS_INET_NTOP(&resource->info.addr, buf1));
     }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -577,7 +577,7 @@ void stats_update_upf_sessions(void)
         ogs_list_for_each(&sess->pfcp.far_list, far) {
             ptr += sprintf(ptr, "act:%u, dest:%u, outer_header_creation:%s\n",
                 far->apply_action, far->dst_if,
-                OGS_INET_NTOP(far->outer_header_creation.addr, buf1));
+                OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
         }
     }
     ogs_write_file_value("upf/fars", buffer);

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -546,7 +546,7 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 #define MAX_APN 63
 #define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16)
 
-static void print_far(char *buf, ogs_pfcp_far_t *far) {
+static char *print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
 
     buf += sprintf(buf, "\tfar ");
@@ -583,7 +583,7 @@ static void print_far(char *buf, ogs_pfcp_far_t *far) {
     }
 
     buf += sprintf(buf, "\n");
-    return;
+    return buf;
 }
 
 void stats_update_upf_sessions(void)
@@ -607,7 +607,7 @@ void stats_update_upf_sessions(void)
             sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "",
             (long)sess->smf_n4_f_seid.seid, (long)sess->upf_n4_seid);
         ogs_list_for_each(&sess->pfcp.far_list, far) {
-            print_far(ptr, far);
+            ptr = print_far(ptr, far);
         }
     }
     ogs_write_file_value("upf/list_sessions", buffer);


### PR DESCRIPTION
Adding a bunch more /tmp variables to help debug (1) the session IDs in-between CPS/UPS and (2) some more details about what exact state the UPS has.