### PR TITLE
handle CreateSessionRequest even when in state operational

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -803,7 +803,29 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
                 OGS_FSM_TRAN(s, &smf_gsm_state_wait_pfcp_deletion);
             }
             break;
-
+        case OGS_GTP2_CREATE_SESSION_REQUEST_TYPE:
+            ogs_warn("received Create Session Request for preexisting session");
+            gtp2_cause = smf_s5c_handle_create_session_request(sess,
+                            e->gtp_xact,
+                            &e->gtp2_message->create_session_request);
+            if (gtp2_cause != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+                send_gtp_create_err_msg(sess, e->gtp_xact, gtp2_cause);
+                return;
+            }
+            switch (sess->gtp_rat_type) {
+            case OGS_GTP2_RAT_TYPE_EUTRAN:
+                if (send_ccr_init_req_gx_gy(sess, e) == true)
+                    OGS_FSM_TRAN(s, smf_gsm_state_wait_epc_auth_initial);
+                break;
+            case OGS_GTP2_RAT_TYPE_WLAN:
+                smf_s6b_send_aar(sess, e->gtp_xact);
+                OGS_FSM_TRAN(s, smf_gsm_state_wait_epc_auth_initial);
+                break;
+            default:
+                ogs_error("Unknown RAT Type [%d]", sess->gtp_rat_type);
+                ogs_assert_if_reached();
+            }
+            break;
         default:
             ogs_error("Not implmeneted(type:%d)", gtp2_message->h.type);
         }


### PR DESCRIPTION
we have observed some cases where the smf receives a CreateSessionRequest (from sgwc) for a preexisting session. Currently (when in state operational) the smf just silently drops this message, which in turn blocks the rest of the registration procedure. Preferred idempotent behavior would be to handle the CSR message by removing any active sessions and proceeding as if it were a new request.