### PR TITLE
print full tunnel information in /tmp/open5gs

### DIFF
--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1901,7 +1901,7 @@ static char *stats_print_far(char *buf, ogs_pfcp_far_t *far) {
         buf += sprintf(buf, "dst_teid:0x%x dst_addr:%s ",
             far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     } else {
-        buf += sprintf(buf, "dst_teid:DEENCAP ");
+        buf += sprintf(buf, "dst_teid:OGSTUN ");
     }
 
     return buf;
@@ -1925,12 +1925,16 @@ char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr) {
         buf += sprintf(buf, "src_if:%u ", pdr->src_if);
     }
 
-    buf += sprintf(buf, "src_teid:0x%x ", pdr->hash.teid.key);
+    if (pdr->hash.teid.key != 0) {
+        buf += sprintf(buf, "src_teid:0x%x ", pdr->hash.teid.key);
+    } else {
+        buf += sprintf(buf, "src_teid:OGSTUN ");
+    }
 
     if (pdr->far) {
         buf = stats_print_far(buf, pdr->far);
     } else {
-        buf += sprintf(buf, "FAR: NULL");
+        buf += sprintf(buf, "far: NULL ");
     }
 
     return buf;

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1891,7 +1891,7 @@ char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr) {
     buf += sprintf(buf, "src_teid:0x%x ", pdr->hash.teid.key);
 
     if (pdr->far) {
-        stats_print_far(buf, pdr->far);
+        buf = stats_print_far(buf, pdr->far);
     } else {
         buf += sprintf(buf, "FAR: NULL");
     }

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1870,39 +1870,8 @@ void ogs_pfcp_pool_final(ogs_pfcp_sess_t *sess)
     ogs_index_final(&sess->bar_id_pool);
 }
 
-char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr) {
-
-    buf += sprintf(buf, "\tpdr ");
-
-    switch (pdr->src_if) {
-    case OGS_PFCP_INTERFACE_ACCESS:
-        buf += sprintf(buf, "src_if:ACCESS ");
-        break;
-    case OGS_PFCP_INTERFACE_CORE:
-        buf += sprintf(buf, "src_if:CORE ");
-        break;
-    case OGS_PFCP_INTERFACE_CP_FUNCTION:
-        buf += sprintf(buf, "src_if:CP ");
-        break;
-    default:
-        buf += sprintf(buf, "src_if:%u ", pdr->src_if);
-    }
-
-    buf += sprintf(buf, "src_teid:0x%x ", pdr->hash.teid.key);
-
-    if (pdr->far) {
-        buf = stats_print_far(buf, pdr->far);
-    } else {
-        buf += sprintf(buf, "FAR: NULL");
-    }
-
-    return buf;
-}
-
-char *stats_print_far(char *buf, ogs_pfcp_far_t *far) {
+static char *stats_print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
-
-    buf += sprintf(buf, "FAR: ");
 
     if (far->apply_action & OGS_PFCP_APPLY_ACTION_DROP) {
         buf += sprintf(buf, "act:DROP ");
@@ -1931,6 +1900,37 @@ char *stats_print_far(char *buf, ogs_pfcp_far_t *far) {
     if (far->outer_header_creation.addr) {
         buf += sprintf(buf, "dst_teid:0x%x dst_addr:%s ",
             far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+    } else {
+        buf += sprintf(buf, "dst_teid:DEENCAP ");
+    }
+
+    return buf;
+}
+
+char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr) {
+
+    buf += sprintf(buf, "\tpdr ");
+
+    switch (pdr->src_if) {
+    case OGS_PFCP_INTERFACE_ACCESS:
+        buf += sprintf(buf, "src_if:ACCESS ");
+        break;
+    case OGS_PFCP_INTERFACE_CORE:
+        buf += sprintf(buf, "src_if:CORE ");
+        break;
+    case OGS_PFCP_INTERFACE_CP_FUNCTION:
+        buf += sprintf(buf, "src_if:CP ");
+        break;
+    default:
+        buf += sprintf(buf, "src_if:%u ", pdr->src_if);
+    }
+
+    buf += sprintf(buf, "src_teid:0x%x ", pdr->hash.teid.key);
+
+    if (pdr->far) {
+        buf = stats_print_far(buf, pdr->far);
+    } else {
+        buf += sprintf(buf, "FAR: NULL");
     }
 
     return buf;

--- a/lib/pfcp/context.c
+++ b/lib/pfcp/context.c
@@ -1869,3 +1869,69 @@ void ogs_pfcp_pool_final(ogs_pfcp_sess_t *sess)
     ogs_index_final(&sess->qer_id_pool);
     ogs_index_final(&sess->bar_id_pool);
 }
+
+char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr) {
+
+    buf += sprintf(buf, "\tpdr ");
+
+    switch (pdr->src_if) {
+    case OGS_PFCP_INTERFACE_ACCESS:
+        buf += sprintf(buf, "src_if:ACCESS ");
+        break;
+    case OGS_PFCP_INTERFACE_CORE:
+        buf += sprintf(buf, "src_if:CORE ");
+        break;
+    case OGS_PFCP_INTERFACE_CP_FUNCTION:
+        buf += sprintf(buf, "src_if:CP ");
+        break;
+    default:
+        buf += sprintf(buf, "src_if:%u ", pdr->src_if);
+    }
+
+    buf += sprintf(buf, "src_teid:0x%x ", pdr->hash.teid.key);
+
+    if (pdr->far) {
+        stats_print_far(buf, pdr->far);
+    } else {
+        buf += sprintf(buf, "FAR: NULL");
+    }
+
+    return buf;
+}
+
+char *stats_print_far(char *buf, ogs_pfcp_far_t *far) {
+    char buf1[OGS_ADDRSTRLEN];
+
+    buf += sprintf(buf, "FAR: ");
+
+    if (far->apply_action & OGS_PFCP_APPLY_ACTION_DROP) {
+        buf += sprintf(buf, "act:DROP ");
+    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_FORW) {
+        buf += sprintf(buf, "act:FORW ");
+    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_BUFF) {
+        buf += sprintf(buf, "act:BUFF ");
+    } else {
+        buf += sprintf(buf, "act:%u ", far->apply_action);
+    }
+
+    switch (far->dst_if) {
+    case OGS_PFCP_INTERFACE_ACCESS:
+        buf += sprintf(buf, "dst_if:ACCESS ");
+        break;
+    case OGS_PFCP_INTERFACE_CORE:
+        buf += sprintf(buf, "dst_if:CORE ");
+        break;
+    case OGS_PFCP_INTERFACE_CP_FUNCTION:
+        buf += sprintf(buf, "dst_if:CP ");
+        break;
+    default:
+        buf += sprintf(buf, "dst_if:%u ", far->dst_if);
+    }
+
+    if (far->outer_header_creation.addr) {
+        buf += sprintf(buf, "dst_teid:0x%x dst_addr:%s ",
+            far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+    }
+
+    return buf;
+}

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -470,11 +470,10 @@ ogs_pfcp_subnet_t *ogs_pfcp_find_subnet_by_dnn(int family, const char *dnn);
 void ogs_pfcp_pool_init(ogs_pfcp_sess_t *sess);
 void ogs_pfcp_pool_final(ogs_pfcp_sess_t *sess);
 
-#define MAX_PDR_STRING_LEN 38
 #define MAX_FAR_STRING_LEN (38 + INET6_ADDRSTRLEN)
+#define MAX_PDR_STRING_LEN 38 + MAX_FAR_STRING_LEN
 
 char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr);
-char *stats_print_far(char *buf, ogs_pfcp_far_t *far);
 
 #ifdef __cplusplus
 }

--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -470,6 +470,12 @@ ogs_pfcp_subnet_t *ogs_pfcp_find_subnet_by_dnn(int family, const char *dnn);
 void ogs_pfcp_pool_init(ogs_pfcp_sess_t *sess);
 void ogs_pfcp_pool_final(ogs_pfcp_sess_t *sess);
 
+#define MAX_PDR_STRING_LEN 38
+#define MAX_FAR_STRING_LEN (38 + INET6_ADDRSTRLEN)
+
+char *stats_print_pdr(char *buf, ogs_pfcp_pdr_t *pdr);
+char *stats_print_far(char *buf, ogs_pfcp_far_t *far);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -914,7 +914,7 @@ static char *print_tun(char *buf, sgwc_tunnel_t *tunnel, uint8_t ebi) {
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
 
-    buf += sprintf(buf, "\ttun ebi:%u", ebi);
+    buf += sprintf(buf, "\ttun ebi:%u ", ebi);
 
     switch (tunnel->interface_type) {
     case OGS_GTP2_F_TEID_S5_S8_SGW_GTP_U:

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -927,7 +927,7 @@ static char *print_tun(char *buf, sgwc_tunnel_t *tunnel, uint8_t ebi) {
         buf += sprintf(buf, "if:%u ", tunnel->interface_type);
     }
 
-    buf += sprintf(buf, "l_teid:%u l_addr:%s r_teid:%u r_addr:%s\n", 
+    buf += sprintf(buf, "l_teid:0x%x l_addr:%s r_teid:0x%x r_addr:%s\n", 
         tunnel->local_teid,
         tunnel->local_addr ? OGS_ADDR(tunnel->local_addr, buf1) : "",
         tunnel->remote_teid, OGS_INET_NTOP(&tunnel->remote_ip.addr, buf2));

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -927,7 +927,7 @@ static char *print_tun(char *buf, sgwc_tunnel_t *tunnel, uint8_t ebi) {
         buf += sprintf(buf, "if:%u ", tunnel->interface_type);
     }
 
-    buf += sprintf(buf, "l_teid:0x%x l_addr:%s r_teid:0x%x r_addr:%s\n", 
+    buf += sprintf(buf, "src_teid:0x%x src_addr:%s dst_teid:0x%x dst_addr:%s\n", 
         tunnel->local_teid,
         tunnel->local_addr ? OGS_ADDR(tunnel->local_addr, buf1) : "",
         tunnel->remote_teid, OGS_INET_NTOP(&tunnel->remote_ip.addr, buf2));

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -929,8 +929,8 @@ static char *print_tun(char *buf, sgwc_tunnel_t *tunnel, uint8_t ebi) {
 
     buf += sprintf(buf, "l_teid:%u l_addr:%s r_teid:%u r_addr:%s\n", 
         tunnel->local_teid,
-        tunnel->local_addr ? OGS_ADDR(&tunnel->local_addr, buf1) : "",
-        tunnel->remote_teid, OGS_INET_NTOP(tunnel->remote_ip.addr, buf2));
+        tunnel->local_addr ? OGS_ADDR(tunnel->local_addr, buf1) : "",
+        tunnel->remote_teid, OGS_INET_NTOP(&tunnel->remote_ip.addr, buf2));
 
     return buf;
 }

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -237,6 +237,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             sgwc_sxa_handle_session_establishment_response(
                 sess, xact, e->gtp_message,
                 &message->pfcp_session_establishment_response);
+            stats_update_sgwc_sessions();
             break;
 
         case OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE:
@@ -248,6 +249,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             sgwc_sxa_handle_session_modification_response(
                 sess, xact, e->gtp_message,
                 &message->pfcp_session_modification_response);
+            stats_update_sgwc_sessions();
             break;
 
         case OGS_PFCP_SESSION_DELETION_RESPONSE_TYPE:
@@ -271,11 +273,13 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
             sgwc_sxa_handle_session_deletion_response(
                 sess, xact, e->gtp_message,
                 &message->pfcp_session_deletion_response);
+            stats_update_sgwc_sessions();
             break;
 
         case OGS_PFCP_SESSION_SET_DELETION_RESPONSE_TYPE:
             sgwc_sxa_handle_session_set_deletion_response(
                 xact, &message->pfcp_session_set_deletion_response);
+            stats_update_sgwc_sessions();
             break;
 
         case OGS_PFCP_SESSION_REPORT_REQUEST_TYPE:
@@ -286,6 +290,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
 
             sgwc_sxa_handle_session_report_request(
                 sess, xact, &message->pfcp_session_report_request);
+            stats_update_sgwc_sessions();
             break;
 
         default:

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -261,6 +261,8 @@ void sgwc_s5c_handle_create_session_response(
     ogs_assert(pgw_s5c_teid);
     sess->pgw_s5c_teid = be32toh(pgw_s5c_teid->teid);
 
+    stats_update_sgwc_sessions();
+
     ogs_assert(OGS_OK ==
         sgwc_pfcp_send_session_modification_request(
             sess, s11_xact, gtpbuf,
@@ -360,6 +362,8 @@ void sgwc_s5c_handle_delete_session_response(
         sgwc_ue->mme_s11_teid, sgwc_ue->sgw_s11_teid);
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
+
+    stats_update_sgwc_sessions();
 
     /*
      * 1. MME sends Delete Session Request to SGW/SMF.
@@ -479,6 +483,8 @@ void sgwc_s5c_handle_modify_bearer_response(
         sgwc_ue->mme_s11_teid, sgwc_ue->sgw_s11_teid);
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
+
+    stats_update_sgwc_sessions();
 
     if (modify_action == OGS_GTP_MODIFY_IN_PATH_SWITCH_REQUEST) {
         ogs_assert(OGS_OK ==
@@ -612,6 +618,8 @@ void sgwc_s5c_handle_create_bearer_request(
             &far->outer_header_creation, &far->outer_header_creation_len));
     far->outer_header_creation.teid = ul_tunnel->remote_teid;
 
+    stats_update_sgwc_sessions();
+
     ogs_assert(OGS_OK ==
         sgwc_pfcp_send_bearer_modification_request(
             bearer, s5c_xact, gtpbuf,
@@ -713,6 +721,8 @@ void sgwc_s5c_handle_update_bearer_request(
 
     rv = ogs_gtp_xact_commit(s11_xact);
     ogs_expect(rv == OGS_OK);
+
+    stats_update_sgwc_sessions();
 
     ogs_debug("Update Bearer Request : SGW <-- PGW");
 }
@@ -859,6 +869,8 @@ void sgwc_s5c_handle_delete_bearer_request(
         rv = ogs_gtp_xact_update_tx(s11_xact, &message->h, pkbuf);
         ogs_expect_or_return(rv == OGS_OK);
     }
+
+    stats_update_sgwc_sessions();
 
     rv = ogs_gtp_xact_commit(s11_xact);
     ogs_expect(rv == OGS_OK);

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -139,8 +139,6 @@ static void sgwc_sxa_handle_session_reestablishment(
     ogs_assert(up_f_seid);
     sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
 
-    stats_update_sgwc_sessions();
-
     return;
 }
 
@@ -333,8 +331,6 @@ void sgwc_sxa_handle_session_establishment_response(
     up_f_seid = pfcp_rsp->up_f_seid.data;
     ogs_assert(up_f_seid);
     sess->sgwu_sxa_seid = be64toh(up_f_seid->seid);
-
-    stats_update_sgwc_sessions();
 
     pgw_s5c_teid = create_session_request->
         pgw_s5_s8_address_for_control_plane_or_pmip.data;

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -286,10 +286,9 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
         buf += sprintf(buf, "if:%u ", far->dst_if);
     }
 
-    buf += sprintf(buf, "teid:%u ", far->hash.f_teid.key.teid);
-
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "dst:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+        buf += sprintf(buf, "teid:0x%x dst:%s ",
+            far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 
     buf += sprintf(buf, "\n");

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -286,8 +286,10 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
         buf += sprintf(buf, "if:%u ", far->dst_if);
     }
 
+    buf += sprintf(buf, "l_teid:%u ", far->hash.teid.key);
+
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "teid:0x%x dst:%s ",
+        buf += sprintf(buf, "f_teid:0x%x dst:%s ",
             far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -255,7 +255,8 @@ sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)
     return sess;
 }
 
-#define MAX_SESSION_STRING_LEN (22 + 16 + 16)
+#define MAX_FAR_STRING_LEN (38 + INET6_ADDRSTRLEN)
+#define MAX_SESSION_STRING_LEN (22 + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_FAR_STRING_LEN))
 
 static char *print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
@@ -273,20 +274,22 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
 
     switch (far->dst_if) {
     case OGS_PFCP_INTERFACE_ACCESS:
-        buf += sprintf(buf, "dst:ACCESS ");
+        buf += sprintf(buf, "if:ACCESS ");
         break;
     case OGS_PFCP_INTERFACE_CORE:
-        buf += sprintf(buf, "dst:CORE ");
+        buf += sprintf(buf, "if:CORE ");
         break;
     case OGS_PFCP_INTERFACE_CP_FUNCTION:
-        buf += sprintf(buf, "dst:CP ");
+        buf += sprintf(buf, "if:CP ");
         break;
     default:
-        buf += sprintf(buf, "dst:%u ", far->dst_if);
+        buf += sprintf(buf, "if:%u ", far->dst_if);
     }
 
+    buf += sprintf(buf, "teid:%u ", far->hash.f_teid.key.teid);
+
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "hdr:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+        buf += sprintf(buf, "dst:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 
     buf += sprintf(buf, "\n");

--- a/src/sgwu/sxa-handler.c
+++ b/src/sgwu/sxa-handler.c
@@ -358,6 +358,8 @@ void sgwu_sxa_handle_session_modification_request(
         }
     }
 
+    stats_update_sgwu_sessions();
+
     ogs_assert(OGS_OK ==
         sgwu_pfcp_send_session_modification_response(
             xact, sess, created_pdr, num_of_created_pdr));
@@ -368,6 +370,7 @@ cleanup:
     ogs_pfcp_send_error_message(xact, sess ? sess->sgwu_sxa_seid : 0,
             OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
             cause_value, offending_ie_value);
+    stats_update_sgwu_sessions();
 }
 
 void sgwu_sxa_handle_session_deletion_request(

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2917,7 +2917,7 @@ static char *print_bearer(char *buf, smf_bearer_t *bearer) {
 
     buf += sprintf(buf, "\tbearer ebi:%u ", bearer->ebi);
 
-    buf += sprintf(buf, "l_teid:0x%x l_addr:%s r_teid:0x%x r_addr:%s\n",
+    buf += sprintf(buf, "src_teid:0x%x src_addr:%s dst_teid:0x%x dst_addr:%s\n",
         bearer->pgw_s5u_teid,
         bearer->pgw_s5u_addr ? OGS_ADDR(bearer->pgw_s5u_addr, buf1) : "",
         bearer->sgw_s5u_teid, OGS_INET_NTOP(&bearer->sgw_s5u_ip.addr, buf2));

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2917,7 +2917,7 @@ static char *print_bearer(char *buf, smf_bearer_t *bearer) {
 
     buf += sprintf(buf, "\tbearer ebi:%u ", bearer->ebi);
 
-    buf += sprintf(buf, "l_teid:%u l_addr:%s r_teid:%u r_addr:%s\n", 
+    buf += sprintf(buf, "l_teid:0x%x l_addr:%s r_teid:0x%x r_addr:%s\n",
         bearer->pgw_s5u_teid,
         bearer->pgw_s5u_addr ? OGS_ADDR(bearer->pgw_s5u_addr, buf1) : "",
         bearer->sgw_s5u_teid, OGS_INET_NTOP(&bearer->sgw_s5u_ip.addr, buf2));

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2919,8 +2919,8 @@ static char *print_bearer(char *buf, smf_bearer_t *bearer) {
 
     buf += sprintf(buf, "l_teid:%u l_addr:%s r_teid:%u r_addr:%s\n", 
         bearer->pgw_s5u_teid,
-        bearer->pgw_s5u_addr ? OGS_ADDR(&bearer->pgw_s5u_addr, buf1) : "",
-        bearer->sgw_s5u_teid, OGS_INET_NTOP(bearer->sgw_s5u_ip.addr, buf2));
+        bearer->pgw_s5u_addr ? OGS_ADDR(bearer->pgw_s5u_addr, buf1) : "",
+        bearer->sgw_s5u_teid, OGS_INET_NTOP(&bearer->sgw_s5u_ip.addr, buf2));
 
     return buf;
 }

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -575,10 +575,9 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
         buf += sprintf(buf, "dst:%u ", far->dst_if);
     }
 
-    buf += sprintf(buf, "teid:%u ", far->hash.f_teid.key.teid);
-
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "dst:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+        buf += sprintf(buf, "teid:0x%x dst:%s ",
+            far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 
     buf += sprintf(buf, "\n");

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -544,50 +544,12 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 }
 
 #define MAX_APN 63
-#define MAX_FAR_STRING_LEN (38 + INET6_ADDRSTRLEN)
 #define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_FAR_STRING_LEN))
-
-static char *print_far(char *buf, ogs_pfcp_far_t *far) {
-    char buf1[OGS_ADDRSTRLEN];
-
-    buf += sprintf(buf, "\tfar ");
-    if (far->apply_action & OGS_PFCP_APPLY_ACTION_DROP) {
-        buf += sprintf(buf, "act:DROP ");
-    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_FORW) {
-        buf += sprintf(buf, "act:FORW ");
-    } else if (far->apply_action & OGS_PFCP_APPLY_ACTION_BUFF) {
-        buf += sprintf(buf, "act:BUFF ");
-    } else {
-        buf += sprintf(buf, "act:%u ", far->apply_action);
-    }
-
-    switch (far->dst_if) {
-    case OGS_PFCP_INTERFACE_ACCESS:
-        buf += sprintf(buf, "if:ACCESS ");
-        break;
-    case OGS_PFCP_INTERFACE_CORE:
-        buf += sprintf(buf, "if:CORE ");
-        break;
-    case OGS_PFCP_INTERFACE_CP_FUNCTION:
-        buf += sprintf(buf, "if:CP ");
-        break;
-    default:
-        buf += sprintf(buf, "dst:%u ", far->dst_if);
-    }
-
-    if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "f_teid:0x%x f_dst:%s ",
-            far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
-    }
-
-    buf += sprintf(buf, "\n");
-    return buf;
-}
 
 void stats_update_upf_sessions(void)
 {
     upf_sess_t *sess = NULL;
-    ogs_pfcp_far_t *far;
+    ogs_pfcp_pdr_t *pdr;
     char buf1[OGS_ADDRSTRLEN];
     char buf2[OGS_ADDRSTRLEN];
     char *buffer = NULL;
@@ -605,8 +567,8 @@ void stats_update_upf_sessions(void)
             sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "",
             (long)sess->smf_n4_f_seid.seid, (long)sess->upf_n4_seid);
         
-        ogs_list_for_each(&sess->pfcp.far_list, far) {
-            ptr = print_far(ptr, far);
+        ogs_list_for_each(&sess->pfcp.pdr_list, pdr) {
+            ptr = stats_print_pdr(ptr, pdr);
         }
     }
     ogs_write_file_value("upf/list_sessions", buffer);

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -569,6 +569,7 @@ void stats_update_upf_sessions(void)
         
         ogs_list_for_each(&sess->pfcp.pdr_list, pdr) {
             ptr = stats_print_pdr(ptr, pdr);
+            ptr += sprintf(ptr, "\n");
         }
     }
     ogs_write_file_value("upf/list_sessions", buffer);

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -575,10 +575,8 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
         buf += sprintf(buf, "dst:%u ", far->dst_if);
     }
 
-    buf += sprintf(buf, "l_teid:%u ", far->hash.teid.key);
-
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "f_teid:0x%x dst:%s ",
+        buf += sprintf(buf, "f_teid:0x%x f_dst:%s ",
             far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -544,7 +544,8 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 }
 
 #define MAX_APN 63
-#define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16)
+#define MAX_FAR_STRING_LEN (38 + INET6_ADDRSTRLEN)
+#define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_FAR_STRING_LEN))
 
 static char *print_far(char *buf, ogs_pfcp_far_t *far) {
     char buf1[OGS_ADDRSTRLEN];
@@ -562,20 +563,22 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
 
     switch (far->dst_if) {
     case OGS_PFCP_INTERFACE_ACCESS:
-        buf += sprintf(buf, "dst:ACCESS ");
+        buf += sprintf(buf, "if:ACCESS ");
         break;
     case OGS_PFCP_INTERFACE_CORE:
-        buf += sprintf(buf, "dst:CORE ");
+        buf += sprintf(buf, "if:CORE ");
         break;
     case OGS_PFCP_INTERFACE_CP_FUNCTION:
-        buf += sprintf(buf, "dst:CP ");
+        buf += sprintf(buf, "if:CP ");
         break;
     default:
         buf += sprintf(buf, "dst:%u ", far->dst_if);
     }
 
+    buf += sprintf(buf, "teid:%u ", far->hash.f_teid.key.teid);
+
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "hdr:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
+        buf += sprintf(buf, "dst:%s ", OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 
     buf += sprintf(buf, "\n");

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -575,8 +575,10 @@ static char *print_far(char *buf, ogs_pfcp_far_t *far) {
         buf += sprintf(buf, "dst:%u ", far->dst_if);
     }
 
+    buf += sprintf(buf, "l_teid:%u ", far->hash.teid.key);
+
     if (far->outer_header_creation.addr) {
-        buf += sprintf(buf, "teid:0x%x dst:%s ",
+        buf += sprintf(buf, "f_teid:0x%x dst:%s ",
             far->hash.f_teid.key.teid, OGS_INET_NTOP(&far->outer_header_creation.addr, buf1));
     }
 

--- a/src/upf/n4-handler.c
+++ b/src/upf/n4-handler.c
@@ -190,6 +190,8 @@ void upf_n4_handle_session_establishment_request(
         }
     }
 
+    stats_update_upf_sessions();
+
     ogs_assert(OGS_OK ==
         upf_pfcp_send_session_establishment_response(
             xact, sess, created_pdr, num_of_created_pdr));
@@ -200,6 +202,7 @@ cleanup:
     ogs_pfcp_send_error_message(xact, sess ? sess->smf_n4_f_seid.seid : 0,
             OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE,
             cause_value, offending_ie_value);
+    stats_update_upf_sessions();
 }
 
 void upf_n4_handle_session_modification_request(
@@ -425,6 +428,8 @@ void upf_n4_handle_session_modification_request(
         }
     }
 
+    stats_update_upf_sessions();
+
     ogs_assert(OGS_OK ==
         upf_pfcp_send_session_modification_response(
             xact, sess, created_pdr, num_of_created_pdr));
@@ -435,6 +440,7 @@ cleanup:
     ogs_pfcp_send_error_message(xact, sess ? sess->smf_n4_f_seid.seid : 0,
             OGS_PFCP_SESSION_MODIFICATION_RESPONSE_TYPE,
             cause_value, offending_ie_value);
+    stats_update_upf_sessions();
 }
 
 void upf_n4_handle_session_deletion_request(


### PR DESCRIPTION
This is a medium-large size improvement to the stats information currently printed in /tmp/open5gs/*/list_sessions. It now correctly prints out the seid information (CP and UP) as well as the teids (used for data-plane GTP tunneling), and links PDRs to FARs in the UPS components.