### PR TITLE
Reduce memory for stats functions

### DIFF
--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3534,7 +3534,7 @@ void stats_update_mme_enbs(void)
     sprintf(num, "%d\n", ogs_list_count(&self.enb_list));
     ogs_write_file_value("mme/num_enbs", num);
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_list_count(&self.enb_list));
     ogs_list_for_each(&self.enb_list, enb) {
         ptr += sprintf(ptr, "ip:%s tac:%u",
             OGS_ADDR(enb->sctp.addr, buf),enb->supported_ta_list[0].tac);
@@ -3559,7 +3559,7 @@ void stats_update_mme_ues(void)
     sprintf(num, "%d\n", ogs_list_count(&self.mme_ue_list));
     ogs_write_file_value("mme/num_ues", num);
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_list_count(&self.mme_ue_list));
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ptr += sprintf(ptr, "imsi:%s enb:%s tac:%d\n", mme_ue->imsi_bcd,
             mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "",
@@ -3588,7 +3588,7 @@ void stats_update_mme_sessions(void)
     sprintf(num, "%d\n", num_of_mme_sess);
     ogs_write_file_value("mme/num_sessions", num);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * num_of_mme_sess);
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ogs_list_for_each(&mme_ue->sess_list, sess) {
             ptr += sprintf(ptr, "imsi:%s enb:%s tac:%d ", mme_ue->imsi_bcd,

--- a/src/mme/mme-context.c
+++ b/src/mme/mme-context.c
@@ -3521,6 +3521,8 @@ static void stats_remove_mme_session(void)
     stats_update_mme_sessions();
 }
 
+#define MAX_ENB_STRING_LEN (8 + OGS_MAX_IMSI_BCD_LEN + INET_ADDRSTRLEN + (8 * 4))
+
 void stats_update_mme_enbs(void)
 {
     mme_enb_t *enb = NULL;
@@ -3534,7 +3536,7 @@ void stats_update_mme_enbs(void)
     sprintf(num, "%d\n", ogs_list_count(&self.enb_list));
     ogs_write_file_value("mme/num_enbs", num);
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_list_count(&self.enb_list));
+    ptr = buffer = ogs_malloc(MAX_ENB_STRING_LEN * ogs_list_count(&self.enb_list));
     ogs_list_for_each(&self.enb_list, enb) {
         ptr += sprintf(ptr, "ip:%s tac:%u",
             OGS_ADDR(enb->sctp.addr, buf),enb->supported_ta_list[0].tac);
@@ -3548,6 +3550,8 @@ void stats_update_mme_enbs(void)
     ogs_free(buffer);
 }
 
+#define MAX_UE_STRING_LEN (17 + OGS_MAX_IMSI_BCD_LEN + INET_ADDRSTRLEN + 3)
+
 void stats_update_mme_ues(void)
 {
     mme_ue_t *mme_ue = NULL;
@@ -3559,7 +3563,7 @@ void stats_update_mme_ues(void)
     sprintf(num, "%d\n", ogs_list_count(&self.mme_ue_list));
     ogs_write_file_value("mme/num_ues", num);
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_list_count(&self.mme_ue_list));
+    ptr = buffer = ogs_malloc(MAX_UE_STRING_LEN * ogs_list_count(&self.mme_ue_list));
     ogs_list_for_each(&self.mme_ue_list, mme_ue) {
         ptr += sprintf(ptr, "imsi:%s enb:%s tac:%d\n", mme_ue->imsi_bcd,
             mme_ue->enb_ue ? OGS_ADDR(mme_ue->enb_ue->enb->sctp.addr, buf1) : "",

--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -898,7 +898,7 @@ void stats_update_sgwc_ues(void)
     sprintf(num, "%d\n", ogs_list_count(&self.sgw_ue_list));
     ogs_write_file_value("sgwc/num_ues", num);
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_list_count(&self.sgw_ue_list));
     ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
         ptr += sprintf(ptr, "%s\n", sgwc_ue->imsi_bcd);
     }
@@ -950,7 +950,7 @@ void stats_update_sgwc_sessions(void) {
     sprintf(num, "%d\n", num_of_sgwc_sess);
     ogs_write_file_value("sgwc/num_sessions", num);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * num_of_sgwc_sess);
     ogs_list_for_each(&self.sgw_ue_list, sgwc_ue) {
         ogs_list_for_each(&sgwc_ue->sess_list, sess) {
             ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s sgwu:%s seid_cp:0x%lx seid_up:0x%lx\n",

--- a/src/sgwu/context.c
+++ b/src/sgwu/context.c
@@ -255,7 +255,7 @@ sgwu_sess_t *sgwu_sess_add_by_message(ogs_pfcp_message_t *message)
     return sess;
 }
 
-#define MAX_SESSION_STRING_LEN (22 + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_FAR_STRING_LEN))
+#define MAX_SESSION_STRING_LEN (22 + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_PDR_STRING_LEN))
 
 void stats_update_sgwu_sessions(void)
 {
@@ -268,7 +268,7 @@ void stats_update_sgwu_sessions(void)
     sprintf(num, "%d\n", ogs_list_count(&self.sess_list));
     ogs_write_file_value("sgwu/num_sessions", num);
 
-    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_list_count(&self.sess_list));
     ogs_list_for_each(&self.sess_list, sess) {
         ptr += sprintf(ptr, "seid_cp:0x%lx seid_up:0x%lx\n",
             (long)sess->sgwc_sxa_f_seid.seid, (long)sess->sgwu_sxa_seid);

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -2899,7 +2899,7 @@ void stats_update_smf_ues(void)
     sprintf(num, "%d\n", ogs_list_count(&self.smf_ue_list));
     ogs_write_file_value("smf/num_ues", num);
 
-    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(OGS_MAX_IMSI_BCD_LEN * ogs_list_count(&self.smf_ue_list));
     ogs_list_for_each(&self.smf_ue_list, smf_ue) {
         ptr += sprintf(ptr, "%s\n", smf_ue->imsi_bcd);
     }
@@ -2939,7 +2939,7 @@ void stats_update_smf_sessions(void) {
     sprintf(num, "%d\n", num_of_smf_sess);
     ogs_write_file_value("smf/num_sessions", num);
 
-    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_malloc(MAX_SESSION_STRING_LEN * num_of_smf_sess);
     ogs_list_for_each(&self.smf_ue_list, smf_ue) {
         ogs_list_for_each(&smf_ue->sess_list, sess) {
             ptr += sprintf(ptr, "imsi:%s apn:%s ip4:%s ip6:%s upf:%s seid_cp:0x%lx seid_up:0x%lx\n",

--- a/src/upf/context.c
+++ b/src/upf/context.c
@@ -544,7 +544,7 @@ static void upf_sess_urr_acc_remove_all(upf_sess_t *sess)
 }
 
 #define MAX_APN 63
-#define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_FAR_STRING_LEN))
+#define MAX_SESSION_STRING_LEN (43 + MAX_APN + INET_ADDRSTRLEN + INET6_ADDRSTRLEN + 16 + 16 + (OGS_MAX_NUM_OF_PDR * MAX_PDR_STRING_LEN))
 
 void stats_update_upf_sessions(void)
 {
@@ -559,7 +559,7 @@ void stats_update_upf_sessions(void)
     sprintf(num, "%d\n", ogs_list_count(&self.sess_list));
     ogs_write_file_value("upf/num_sessions", num);
 
-    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_app()->max.ue);
+    ptr = buffer = ogs_calloc(1, MAX_SESSION_STRING_LEN * ogs_list_count(&self.sess_list));
     ogs_list_for_each(&self.sess_list, sess) {
         ptr += sprintf(ptr, "apn:%s ip4:%s ip6:%s seid_cp:0x%lx seid_up:0x%lx\n",
             sess->dnn ? sess->dnn : "",


### PR DESCRIPTION
Currently, the stats_update_* functions call malloc() with the maximum possible buffer size and the maximum number of possible entities, e.g. `ogs_malloc(MAX_SESSION_STRING_LEN * ogs_app()->max.ue)`. This allocs WAY more memory than is needed (because e.g. max_ue is typically 1024) and causes timeouts/crashes in Github CI due to running out of memory. Reducing them to the current number of units (e.g. `ogs_list_count(&self.sgw_ue_list)`) dramatically reduces the memory allocated each time the function is called.