### PR TITLE
allow fine-grained setting of message timers

### DIFF
--- a/configs/open5gs/amf.yaml.in
+++ b/configs/open5gs/amf.yaml.in
@@ -348,7 +348,9 @@ usrsctp:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 #
 #  o Handover Wait Duration (Default : 300 ms)
 #    Time to wait for AMF to send UEContextReleaseCommand

--- a/configs/open5gs/ausf.yaml.in
+++ b/configs/open5gs/ausf.yaml.in
@@ -177,5 +177,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/bsf.yaml.in
+++ b/configs/open5gs/bsf.yaml.in
@@ -179,5 +179,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/mme.yaml.in
+++ b/configs/open5gs/mme.yaml.in
@@ -411,7 +411,9 @@ usrsctp:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 #
 #  o Handover Wait Duration (Default : 300 ms)
 #    Time to wait for MME to send UEContextReleaseCommand

--- a/configs/open5gs/nrf.yaml.in
+++ b/configs/open5gs/nrf.yaml.in
@@ -141,5 +141,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/nssf.yaml.in
+++ b/configs/open5gs/nssf.yaml.in
@@ -227,5 +227,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/pcf.yaml.in
+++ b/configs/open5gs/pcf.yaml.in
@@ -179,5 +179,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/sgwc.yaml.in
+++ b/configs/open5gs/sgwc.yaml.in
@@ -156,5 +156,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/sgwu.yaml.in
+++ b/configs/open5gs/sgwu.yaml.in
@@ -145,5 +145,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/smf.yaml.in
+++ b/configs/open5gs/smf.yaml.in
@@ -552,7 +552,9 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 #
 #  o Handover Wait Duration (Default : 300 ms)
 #    Time to wait for SMF to send

--- a/configs/open5gs/udm.yaml.in
+++ b/configs/open5gs/udm.yaml.in
@@ -177,5 +177,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/udr.yaml.in
+++ b/configs/open5gs/udr.yaml.in
@@ -187,5 +187,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/configs/open5gs/upf.yaml.in
+++ b/configs/open5gs/upf.yaml.in
@@ -219,5 +219,7 @@ max:
 #
 #  o Message Wait Duration (3000 ms)
 #    message:
-#        duration: 3000
+#        sbi_duration: 3000
+#        gtp_duration: 3000
+#        pfcp_duration: 3000
 time:

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -117,8 +117,6 @@ static void regenerate_all_timer_duration(void)
     self.time.message.sbi.nf_register_interval_in_exception =
                 ogs_time_from_msec(300);
 
-#define PFCP_N1_RESPONSE_RETRY_COUNT  3
-    self.time.message.pfcp.n1_response_rcount = PFCP_N1_RESPONSE_RETRY_COUNT;
     self.time.message.pfcp.t1_response_duration =
         (self.time.message.pfcp_duration /
          (self.time.message.pfcp.n1_response_rcount + 1));
@@ -139,8 +137,6 @@ static void regenerate_all_timer_duration(void)
         ogs_max(ogs_time_from_sec(10),
             self.time.message.sbi.client_wait_duration + ogs_time_from_sec(1));
 
-#define GTP_N3_RESPONSE_RETRY_COUNT  3
-    self.time.message.gtp.n3_response_rcount = GTP_N3_RESPONSE_RETRY_COUNT;
     self.time.message.gtp.t3_response_duration =
         (self.time.message.gtp_duration /
          (self.time.message.gtp.n3_response_rcount + 1));
@@ -224,6 +220,11 @@ static void app_context_prepare(void)
     self.time.message.sbi_duration = ogs_time_from_sec(10);
     self.time.message.gtp_duration = ogs_time_from_sec(10);
     self.time.message.pfcp_duration = ogs_time_from_sec(10);
+
+#define PFCP_N1_RESPONSE_RETRY_COUNT  3
+#define GTP_N3_RESPONSE_RETRY_COUNT  3
+    self.time.message.pfcp.n1_response_rcount = PFCP_N1_RESPONSE_RETRY_COUNT;
+    self.time.message.gtp.n3_response_rcount = GTP_N3_RESPONSE_RETRY_COUNT;
 
     /*
      * Handover Wait Duration : 300 ms (Default)
@@ -560,6 +561,18 @@ int ogs_app_context_parse_config(void)
                             if (v) {
                                 self.time.message.pfcp_duration =
                                     ogs_time_from_msec(atoll(v));
+                                regenerate_all_timer_duration();
+                            }
+                        } else if (!strcmp(msg_key, "pfcp_n1")) {
+                            const char *v = ogs_yaml_iter_value(&msg_iter);
+                            if (v) {
+                                self.time.message.pfcp.n1_response_rcount = atoi(v);
+                                regenerate_all_timer_duration();
+                            }
+                        } else if (!strcmp(msg_key, "gtp_n3")) {
+                            const char *v = ogs_yaml_iter_value(&msg_iter);
+                            if (v) {
+                                self.time.message.gtp.n3_response_rcount = atoi(v);
                                 regenerate_all_timer_duration();
                             }
                         } else

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -104,9 +104,11 @@ static void recalculate_pool_size(void)
 
 static void regenerate_all_timer_duration(void)
 {
-    ogs_assert(self.time.message.duration);
+    ogs_assert(self.time.message.sbi_duration);
+    ogs_assert(self.time.message.gtp_duration);
+    ogs_assert(self.time.message.pfcp_duration);
 
-    self.time.message.sbi.client_wait_duration = self.time.message.duration;
+    self.time.message.sbi.client_wait_duration = self.time.message.sbi_duration;
     self.time.message.sbi.connection_deadline =
         self.time.message.sbi.client_wait_duration + ogs_time_from_sec(1);
     self.time.message.sbi.nf_register_interval =
@@ -118,7 +120,7 @@ static void regenerate_all_timer_duration(void)
 #define PFCP_N1_RESPONSE_RETRY_COUNT  3
     self.time.message.pfcp.n1_response_rcount = PFCP_N1_RESPONSE_RETRY_COUNT;
     self.time.message.pfcp.t1_response_duration =
-        (self.time.message.duration /
+        (self.time.message.pfcp_duration /
          (self.time.message.pfcp.n1_response_rcount + 1));
     ogs_assert(self.time.message.pfcp.t1_response_duration);
 
@@ -140,7 +142,7 @@ static void regenerate_all_timer_duration(void)
 #define GTP_N3_RESPONSE_RETRY_COUNT  3
     self.time.message.gtp.n3_response_rcount = GTP_N3_RESPONSE_RETRY_COUNT;
     self.time.message.gtp.t3_response_duration =
-        (self.time.message.duration /
+        (self.time.message.gtp_duration /
          (self.time.message.gtp.n3_response_rcount + 1));
     ogs_assert(self.time.message.gtp.t3_response_duration);
 
@@ -152,8 +154,10 @@ static void regenerate_all_timer_duration(void)
     ogs_assert(self.time.message.gtp.t3_holding_duration);
 
 #if 0
-    ogs_trace("%lld, %lld, %lld, %d, %lld, %d %lld, %d, %lld, %d, %lld",
-        (long long)self.time.message.duration,
+    ogs_trace("%lld, %lld, %lld, %lld, %lld, %d, %lld, %d %lld, %d, %lld, %d, %lld",
+        (long long)self.time.message.sbi_duration,
+        (long long)self.time.message.gtp_duration,
+        (long long)self.time.message.pfcp_duration,
         (long long)self.time.message.sbi.client_wait_duration,
         (long long)self.time.message.sbi.connection_deadline,
         self.time.message.pfcp.n1_response_rcount,
@@ -216,7 +220,9 @@ static void app_context_prepare(void)
      * It is recomended to set at least 9 seconds to reflect
      * the paging failure result to GTPv2-C or HTTP2(SBI).
      */
-    self.time.message.duration = ogs_time_from_sec(10);
+    self.time.message.sbi_duration = ogs_time_from_sec(10);
+    self.time.message.gtp_duration = ogs_time_from_sec(10);
+    self.time.message.pfcp_duration = ogs_time_from_sec(10);
 
     /*
      * Handover Wait Duration : 300 ms (Default)
@@ -527,10 +533,24 @@ int ogs_app_context_parse_config(void)
                             ogs_yaml_iter_key(&msg_iter);
                         ogs_assert(msg_key);
 
-                        if (!strcmp(msg_key, "duration")) {
+                        if (!strcmp(msg_key, "sbi_duration")) {
                             const char *v = ogs_yaml_iter_value(&msg_iter);
                             if (v) {
-                                self.time.message.duration =
+                                self.time.message.sbi_duration =
+                                    ogs_time_from_msec(atoll(v));
+                                regenerate_all_timer_duration();
+                            }
+                        } else if (!strcmp(msg_key, "gtp_duration")) {
+                            const char *v = ogs_yaml_iter_value(&msg_iter);
+                            if (v) {
+                                self.time.message.gtp_duration =
+                                    ogs_time_from_msec(atoll(v));
+                                regenerate_all_timer_duration();
+                            }
+                        } else if (!strcmp(msg_key, "pfcp_duration")) {
+                            const char *v = ogs_yaml_iter_value(&msg_iter);
+                            if (v) {
+                                self.time.message.pfcp_duration =
                                     ogs_time_from_msec(atoll(v));
                                 regenerate_all_timer_duration();
                             }

--- a/lib/app/ogs-context.c
+++ b/lib/app/ogs-context.c
@@ -220,6 +220,7 @@ static void app_context_prepare(void)
      * It is recomended to set at least 9 seconds to reflect
      * the paging failure result to GTPv2-C or HTTP2(SBI).
      */
+    self.time.message.diameter_timeout = ogs_time_from_sec(3);
     self.time.message.sbi_duration = ogs_time_from_sec(10);
     self.time.message.gtp_duration = ogs_time_from_sec(10);
     self.time.message.pfcp_duration = ogs_time_from_sec(10);
@@ -533,7 +534,14 @@ int ogs_app_context_parse_config(void)
                             ogs_yaml_iter_key(&msg_iter);
                         ogs_assert(msg_key);
 
-                        if (!strcmp(msg_key, "sbi_duration")) {
+                        if (!strcmp(msg_key, "diameter_timeout")) {
+                            const char *v = ogs_yaml_iter_value(&msg_iter);
+                            if (v) {
+                                self.time.message.diameter_timeout =
+                                    ogs_time_from_msec(atoll(v));
+                                regenerate_all_timer_duration();
+                            }
+                        } else if (!strcmp(msg_key, "sbi_duration")) {
                             const char *v = ogs_yaml_iter_value(&msg_iter);
                             if (v) {
                                 self.time.message.sbi_duration =

--- a/lib/app/ogs-context.h
+++ b/lib/app/ogs-context.h
@@ -144,6 +144,7 @@ typedef struct ogs_app_context_s {
         } subscription;
 
         struct {
+            ogs_time_t diameter_timeout;
             ogs_time_t sbi_duration;
             ogs_time_t gtp_duration;
             ogs_time_t pfcp_duration;

--- a/lib/app/ogs-context.h
+++ b/lib/app/ogs-context.h
@@ -144,7 +144,10 @@ typedef struct ogs_app_context_s {
         } subscription;
 
         struct {
-            ogs_time_t duration;
+            ogs_time_t sbi_duration;
+            ogs_time_t gtp_duration;
+            ogs_time_t pfcp_duration;
+
             struct {
                 ogs_time_t client_wait_duration;
                 ogs_time_t connection_deadline;

--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -176,7 +176,11 @@ static void sess_timeout(ogs_pfcp_xact_t *pfcp_xact, void *data)
     ogs_assert(sess);
 
     s11_xact = pfcp_xact->assoc_xact;
-    ogs_assert(s11_xact);
+
+    if (!s11_xact) {
+        ogs_error("SPENCER no s11_xact!");
+        return;
+    }
 
     switch (s11_xact->gtp_version) {
     case 1:

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -36,9 +36,6 @@
 #include "ngap-path.h"
 #include "fd-path.h"
 
-#define SMF_SESS_GX_TIMEOUT ogs_time_from_sec(3)
-#define SMF_SESS_GY_TIMEOUT ogs_time_from_sec(3)
-
 static uint8_t gtp_cause_from_diameter(uint8_t gtp_version,
         const uint32_t dia_err, const uint32_t *dia_exp_err)
 {
@@ -112,7 +109,7 @@ static bool send_ccr_init_req_gx_gy(smf_sess_t *sess, smf_event_t *e)
     sess->timer_gx_cca = ogs_timer_add(ogs_app()->timer_mgr,
             smf_timer_gx_no_cca, e);
     ogs_assert(sess->timer_gx_cca);
-    ogs_timer_start(sess->timer_gx_cca, SMF_SESS_GX_TIMEOUT);
+    ogs_timer_start(sess->timer_gx_cca, ogs_app()->time.message.diameter_timeout);
     smf_gx_send_ccr(sess, e->gtp_xact,
         OGS_DIAM_GX_CC_REQUEST_TYPE_INITIAL_REQUEST);
 
@@ -123,7 +120,7 @@ static bool send_ccr_init_req_gx_gy(smf_sess_t *sess, smf_event_t *e)
         sess->timer_gy_cca = ogs_timer_add(ogs_app()->timer_mgr,
                 smf_timer_gy_no_cca, e);
         ogs_assert(sess->timer_gy_cca);
-        ogs_timer_start(sess->timer_gy_cca, SMF_SESS_GY_TIMEOUT);
+        ogs_timer_start(sess->timer_gy_cca, ogs_app()->time.message.diameter_timeout);
         smf_gy_send_ccr(sess, e->gtp_xact,
             OGS_DIAM_GY_CC_REQUEST_TYPE_INITIAL_REQUEST);
     }
@@ -160,7 +157,7 @@ static bool send_ccr_termination_req_gx_gy_s6b(smf_sess_t *sess, smf_event_t *e)
         sess->sm_data.gx_ccr_term_in_flight = true;
         sess->timer_gx_cca = ogs_timer_add(ogs_app()->timer_mgr, smf_timer_gx_no_cca, e);
         ogs_assert(sess->timer_gx_cca);
-        ogs_timer_start(sess->timer_gx_cca, SMF_SESS_GX_TIMEOUT);
+        ogs_timer_start(sess->timer_gx_cca, ogs_app()->time.message.diameter_timeout);
         smf_gx_send_ccr(sess, e->gtp_xact,
             OGS_DIAM_GX_CC_REQUEST_TYPE_TERMINATION_REQUEST);
     }
@@ -172,7 +169,7 @@ static bool send_ccr_termination_req_gx_gy_s6b(smf_sess_t *sess, smf_event_t *e)
         sess->timer_gy_cca = ogs_timer_add(ogs_app()->timer_mgr,
                 smf_timer_gy_no_cca, e);
         ogs_assert(sess->timer_gy_cca);
-        ogs_timer_start(sess->timer_gy_cca, SMF_SESS_GY_TIMEOUT);
+        ogs_timer_start(sess->timer_gy_cca, ogs_app()->time.message.diameter_timeout);
         smf_gy_send_ccr(sess, e->gtp_xact,
             OGS_DIAM_GY_CC_REQUEST_TYPE_TERMINATION_REQUEST);
     }
@@ -328,7 +325,7 @@ void smf_gsm_state_initial(ogs_fsm_t *s, smf_event_t *e)
                 sess->timer_gx_cca = ogs_timer_add(ogs_app()->timer_mgr,
                         smf_timer_gx_no_cca, e);
                 ogs_assert(sess->timer_gx_cca);
-                ogs_timer_start(sess->timer_gx_cca, SMF_SESS_GX_TIMEOUT);
+                ogs_timer_start(sess->timer_gx_cca, ogs_app()->time.message.diameter_timeout);
                 smf_s6b_send_aar(sess, e->gtp_xact);
                 OGS_FSM_TRAN(s, smf_gsm_state_wait_epc_auth_initial);
                 break;


### PR DESCRIPTION
Right now the timeout/retransmit values for almost all messages (GTP, PFCP, SBI, Diameter) are set to message.duration (default value 10sec). Having all these timers set to the same value can create weird race-conditions when something times out; to this point the 3GPP specifically recommends fine-tuning these parameters to appropriate values. For example, mme->sgwc GTPv2 messages should naturally have a longer timeout than sgwc->smf GTPv2 messages or sgwc->sgwu PFCP messages. This PR addresses this limitation by breaking up message.duration into sub-parameters (gtp_duration, sbi_duration, pfcp_duration), each of which is individually configurable.