### PR TITLE
add sanity checks to ogs_timer alloc/free

### DIFF
--- a/lib/core/ogs-timer.c
+++ b/lib/core/ogs-timer.c
@@ -79,12 +79,6 @@ ogs_timer_t *ogs_timer_add(
     ogs_pool_alloc(&manager->pool, &timer);
     ogs_assert(timer);
 
-    if(timer->assigned) {
-        // no way to recover here; we're overwriting an active timer
-        ogs_fatal("ogs_timer_add timer already assigned");
-        ogs_abort();
-    }
-
     memset(timer, 0, sizeof *timer);
     timer->cb = cb;
     timer->data = data;

--- a/lib/core/ogs-timer.h
+++ b/lib/core/ogs-timer.h
@@ -39,6 +39,8 @@ typedef struct ogs_timer_s {
     ogs_timer_mgr_t *manager;
     bool running;
     ogs_time_t timeout;
+
+    bool assigned;
 } ogs_timer_t;
 
 ogs_timer_mgr_t *ogs_timer_mgr_create(unsigned int capacity);


### PR DESCRIPTION
We recently fixed a timer leak issue that was incredibly hard to understand, in no small part because it's currently possible to re-assign or double-free timers and mess with the values of unassigned items in the pool. The doublefree is now caught, but setting/clearing an "assigned" bit will protect the timer pool and allow us to quickly identify and debug these issues in the future.