### PR TITLE
fix double-free of diameter ogs_timer

### DIFF
--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -454,6 +454,7 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
                 sess->sm_data.gx_ccr_init_in_flight = false;
                 ogs_timer_stop(sess->timer_gx_cca);
                 ogs_timer_delete(sess->timer_gx_cca);
+                sess->timer_gx_cca = NULL;
 
                 sess->sm_data.gx_cca_init_err = diam_err;
                 sess->teardown_gx = true;
@@ -477,6 +478,7 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
                 sess->sm_data.gy_ccr_init_in_flight = false;
                 ogs_timer_stop(sess->timer_gy_cca);
                 ogs_timer_delete(sess->timer_gy_cca);
+                sess->timer_gy_cca = NULL;
                 sess->sm_data.gy_cca_init_err = diam_err;
                 sess->teardown_gy = true;
                 goto test_can_proceed;
@@ -492,6 +494,7 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
             sess->sm_data.gx_ccr_init_in_flight = false;
             ogs_timer_stop(sess->timer_gx_cca);
             ogs_timer_delete(sess->timer_gx_cca);
+            sess->timer_gx_cca = NULL;
             sess->sm_data.gx_cca_init_err = ER_DIAMETER_UNABLE_TO_DELIVER;
             goto test_can_proceed;
         case SMF_TIMER_GY_CCA:
@@ -499,6 +502,7 @@ void smf_gsm_state_wait_epc_auth_initial(ogs_fsm_t *s, smf_event_t *e)
             sess->sm_data.gy_ccr_init_in_flight = false;
             ogs_timer_stop(sess->timer_gy_cca);
             ogs_timer_delete(sess->timer_gy_cca);
+            sess->timer_gy_cca = NULL;
             sess->sm_data.gy_cca_init_err = ER_DIAMETER_UNABLE_TO_DELIVER;
             goto test_can_proceed;
         }
@@ -1564,6 +1568,7 @@ void smf_gsm_state_wait_epc_auth_release(ogs_fsm_t *s, smf_event_t *e)
                 sess->sm_data.gx_ccr_term_in_flight = false;
                 ogs_timer_stop(sess->timer_gx_cca);
                 ogs_timer_delete(sess->timer_gx_cca);
+                sess->timer_gx_cca = NULL;
                 sess->sm_data.gx_cca_term_err = diam_err;
                 goto test_can_proceed;
             }
@@ -1585,6 +1590,7 @@ void smf_gsm_state_wait_epc_auth_release(ogs_fsm_t *s, smf_event_t *e)
                 sess->sm_data.gy_ccr_term_in_flight = false;
                 ogs_timer_stop(sess->timer_gy_cca);
                 ogs_timer_delete(sess->timer_gy_cca);
+                sess->timer_gy_cca = NULL;
                 sess->sm_data.gy_cca_term_err = diam_err;
                 goto test_can_proceed;
             }
@@ -1612,6 +1618,7 @@ void smf_gsm_state_wait_epc_auth_release(ogs_fsm_t *s, smf_event_t *e)
             sess->sm_data.gx_ccr_term_in_flight = false;
             ogs_timer_stop(sess->timer_gx_cca);
             ogs_timer_delete(sess->timer_gx_cca);
+            sess->timer_gx_cca = NULL;
             sess->sm_data.gx_cca_term_err = ER_DIAMETER_UNABLE_TO_DELIVER;
             goto test_can_proceed;
         case SMF_TIMER_GY_CCA:
@@ -1619,6 +1626,7 @@ void smf_gsm_state_wait_epc_auth_release(ogs_fsm_t *s, smf_event_t *e)
             sess->sm_data.gy_ccr_term_in_flight = false;
             ogs_timer_stop(sess->timer_gy_cca);
             ogs_timer_delete(sess->timer_gy_cca);
+            sess->timer_gy_cca = NULL;
             sess->sm_data.gy_cca_term_err = ER_DIAMETER_UNABLE_TO_DELIVER;
             goto test_can_proceed;
         }
@@ -1835,9 +1843,11 @@ void smf_gsm_state_session_will_release(ogs_fsm_t *s, smf_event_t *e)
     case OGS_FSM_ENTRY_SIG:
         if (sess->timer_gx_cca) {
             ogs_timer_delete(sess->timer_gx_cca);
+            sess->timer_gx_cca = NULL;
         }
         if (sess->timer_gy_cca) {
             ogs_timer_delete(sess->timer_gy_cca);
+            sess->timer_gy_cca = NULL;
         }
 
         SMF_SESS_CLEAR(sess);
@@ -1871,9 +1881,11 @@ void smf_gsm_state_exception(ogs_fsm_t *s, smf_event_t *e)
     case OGS_FSM_ENTRY_SIG:
         if (sess->timer_gx_cca) {
             ogs_timer_delete(sess->timer_gx_cca);
+            sess->timer_gx_cca = NULL;            
         }
         if (sess->timer_gy_cca) {
             ogs_timer_delete(sess->timer_gy_cca);
+            sess->timer_gy_cca = NULL;
         }
 
         ogs_error("[%s:%d] State machine exception", smf_ue->supi, sess->psi);
@@ -1900,8 +1912,10 @@ void smf_gsm_state_final(ogs_fsm_t *s, smf_event_t *e)
 
     if (sess->timer_gx_cca) {
         ogs_timer_delete(sess->timer_gx_cca);
+        sess->timer_gx_cca = NULL;        
     }
     if (sess->timer_gy_cca) {
         ogs_timer_delete(sess->timer_gy_cca);
+        sess->timer_gy_cca = NULL;
     }
 }


### PR DESCRIPTION
I incorrectly assumed that ogs_timer_delete() was idempotent, but it is not! As such we need to set the pointer to NULL and put our own subsequent checks in to ensure that every timer pointer gets freed once and only once.