### PR TITLE
only resend established pfcp sessions on reassociation

### DIFF
--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -318,8 +318,10 @@ int sgwc_pfcp_resend_established_sessions(ogs_pfcp_node_t *node)
     ogs_list_for_each(&sgwc_self()->sgw_ue_list, sgwc_ue) {
         ogs_list_for_each(&sgwc_ue->sess_list, sess) {
             if (sess->pfcp_node == node) {
-                sess->sgwu_sxa_seid = 0;
-                sgwc_pfcp_send_session_establishment_request(sess, NULL, NULL);                
+                if (sess->pfcp_established) {
+                    sess->sgwu_sxa_seid = 0;
+                    sgwc_pfcp_send_session_establishment_request(sess, NULL, NULL);                
+                }
             }
         }
     }

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -277,8 +277,6 @@ void sgwc_sxa_handle_session_establishment_response(
 
     ogs_assert(sess);
 
-    sess->pfcp_established = true;
-
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
 
@@ -349,6 +347,8 @@ void sgwc_sxa_handle_session_establishment_response(
     }
     /* Setup GTP Node */
     OGS_SETUP_GTP_NODE(sess, pgw);
+
+    sess->pfcp_established = true;
 
     /* Check Indication */
     if (create_session_request->indication_flags.presence &&

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -414,6 +414,7 @@ typedef struct smf_sess_s {
     bool teardown_gx;
     bool teardown_gy;
     bool teardown_gtp;
+    bool pfcp_established;
 } smf_sess_t;
 
 void smf_context_init(void);

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -880,9 +880,11 @@ void smf_gsm_state_operational(ogs_fsm_t *s, smf_event_t *e)
 
     switch (e->id) {
     case OGS_FSM_ENTRY_SIG:
+        sess->pfcp_established = true;
         break;
 
     case OGS_FSM_EXIT_SIG:
+        sess->pfcp_established = false;
         break;
 
     case SMF_EVT_GN_MESSAGE:

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -470,7 +470,9 @@ int smf_epc_pfcp_resend_established_sessions(ogs_pfcp_node_t *node)
     ogs_list_for_each(&smf_self()->smf_ue_list, smf_ue) {
         ogs_list_for_each(&smf_ue->sess_list, sess) {
             if (sess->pfcp_node == node) {
-                smf_epc_pfcp_send_session_establishment_request(sess, NULL);
+                if (sess->pfcp_established) {
+                    smf_epc_pfcp_send_session_establishment_request(sess, NULL);
+                }
             }
         }
     }


### PR DESCRIPTION
Right now, when PFCP reassociates a CPS (sgwc or smf) with UPS (sgwu or upf), the CPS re-sends a CSR for all PFCP sessions it has associated with the UPS, including any sessions that were in the middle of being established or torn down. This is a simple fix to ensure that it only re-sends requests for any active (already fully established) sessions.