### PR TITLE
more articulate/unique GTP error messages

### DIFF
--- a/src/sgwc/pfcp-path.c
+++ b/src/sgwc/pfcp-path.c
@@ -182,7 +182,7 @@ static void sess_timeout(ogs_pfcp_xact_t *pfcp_xact, void *data)
         gtp_cause = OGS_GTP1_CAUSE_NETWORK_FAILURE;
         break;
     case 2:
-        gtp_cause = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+        gtp_cause = OGS_GTP2_CAUSE_TIMED_OUT_REQUEST;
         break;
     }
 

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -44,6 +44,8 @@ static uint8_t gtp_cause_from_diameter(uint8_t gtp_version,
         switch (dia_err) {
         case OGS_DIAM_UNKNOWN_SESSION_ID:
             return OGS_GTP1_CAUSE_APN_ACCESS_DENIED;
+        case ER_DIAMETER_UNABLE_TO_DELIVER:
+            return OGS_GTP1_CAUSE_USER_AUTHENTICATION_FAILED;
         }
         break;
     case 2:
@@ -51,7 +53,7 @@ static uint8_t gtp_cause_from_diameter(uint8_t gtp_version,
         case OGS_DIAM_UNKNOWN_SESSION_ID:
             return OGS_GTP2_CAUSE_APN_ACCESS_DENIED_NO_SUBSCRIPTION;
         case ER_DIAMETER_UNABLE_TO_DELIVER:
-            return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+            return OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
         }
         break;
     }
@@ -836,7 +838,7 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
                     gtp_cause = OGS_GTP1_CAUSE_NETWORK_FAILURE;
                     break;
                 case 2:
-                    gtp_cause = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+                    gtp_cause = OGS_GTP2_CAUSE_TIMED_OUT_REQUEST;
                     break;
             }
             send_gtp_create_err_msg(sess, e->gtp_xact, gtp_cause);
@@ -1504,7 +1506,7 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                     gtp_cause = OGS_GTP1_CAUSE_NETWORK_FAILURE;
                     break;
                 case 2:
-                    gtp_cause = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+                    gtp_cause = OGS_GTP2_CAUSE_TIMED_OUT_REQUEST;
                     break;
             }
             send_gtp_delete_err_msg(sess, e->gtp_xact, gtp_cause);

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -148,7 +148,7 @@ uint8_t smf_s5c_handle_create_session_request(
 
     if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
         ogs_error("No Gx Diameter Peer");
-        cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+        cause_value = OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
     }
     switch (sess->gtp_rat_type) {
     case OGS_GTP2_RAT_TYPE_EUTRAN:
@@ -165,7 +165,7 @@ uint8_t smf_s5c_handle_create_session_request(
     case OGS_GTP2_RAT_TYPE_WLAN:
         if (!ogs_diam_app_connected(OGS_DIAM_S6B_APPLICATION_ID)) {
             ogs_error("No S6b Diameter Peer");
-            cause_value = OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+            cause_value = OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
         }
         if (req->bearer_contexts_to_be_created[0].
                 s2b_u_epdg_f_teid_5.presence == 0) {
@@ -406,13 +406,13 @@ uint8_t smf_s5c_handle_delete_session_request(
 
     if (!ogs_diam_app_connected(OGS_DIAM_GX_APPLICATION_ID)) {
         ogs_error("No Gx Diameter Peer");
-        return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+        return OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
     }
 
     if (sess->gtp_rat_type == OGS_GTP2_RAT_TYPE_WLAN) {
         if (!ogs_diam_app_connected(OGS_DIAM_S6B_APPLICATION_ID)) {
             ogs_error("No S6b Diameter Peer");
-            return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
+            return OGS_GTP2_CAUSE_UE_NOT_AUTHORISED_BY_OCS_OR_EXTERNAL_AAA_SERVER;
         }
     }
 


### PR DESCRIPTION
Right now almost all failures get coded as "OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING." If we code different failures as different GTP error messages, it makes it easier to glean a bit of information from the failure from a quick glance at the logs.