### PR TITLE
[pfcp] timer needs a pointer to pfcp_xact

### DIFF
--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -415,6 +415,8 @@ typedef struct smf_sess_s {
     bool teardown_gy;
     bool teardown_gtp;
     bool pfcp_established;
+    ogs_pfcp_xact_t *timeout_xact;
+
 } smf_sess_t;
 
 void smf_context_init(void);

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -715,6 +715,8 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
     ogs_pfcp_xact_t *pfcp_xact = NULL;
     ogs_pfcp_message_t *pfcp_message = NULL;
 
+    ogs_gtp_xact_t *gtp_xact = NULL;
+
     ogs_assert(s);
     ogs_assert(e);
 
@@ -833,7 +835,9 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
         switch(e->timer_id) {
         case SMF_TIMEOUT_PFCP_SER:
             ogs_error("PFCP timeout waiting for Session Establishment Response");
-            switch (e->gtp_xact->gtp_version) {
+            gtp_xact = (ogs_gtp_xact_t *) sess->timeout_xact->assoc_xact;            
+
+            switch (gtp_xact->gtp_version) {
                 case 1:
                     gtp_cause = OGS_GTP1_CAUSE_NETWORK_FAILURE;
                     break;
@@ -841,7 +845,7 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
                     gtp_cause = OGS_GTP2_CAUSE_TIMED_OUT_REQUEST;
                     break;
             }
-            send_gtp_create_err_msg(sess, e->gtp_xact, gtp_cause);
+            send_gtp_create_err_msg(sess, gtp_xact, gtp_cause);
             OGS_FSM_TRAN(s, smf_gsm_state_teardown);
             break;
 
@@ -1501,7 +1505,9 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
         switch(e->timer_id) {
         case SMF_TIMEOUT_PFCP_SDR:
             ogs_error("PFCP timeout waiting for Session Deletion Response");
-            switch (e->gtp_xact->gtp_version) {
+            gtp_xact = (ogs_gtp_xact_t *) sess->timeout_xact->assoc_xact;
+
+            switch (gtp_xact->gtp_version) {
                 case 1:
                     gtp_cause = OGS_GTP1_CAUSE_NETWORK_FAILURE;
                     break;
@@ -1509,7 +1515,7 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
                     gtp_cause = OGS_GTP2_CAUSE_TIMED_OUT_REQUEST;
                     break;
             }
-            send_gtp_delete_err_msg(sess, e->gtp_xact, gtp_cause);
+            send_gtp_delete_err_msg(sess, gtp_xact, gtp_cause);
             sess->teardown_gtp = false;
             OGS_FSM_TRAN(s, &smf_gsm_state_teardown);
             break;

--- a/src/smf/pfcp-path.c
+++ b/src/smf/pfcp-path.c
@@ -240,9 +240,13 @@ static void sess_5gc_timeout(ogs_pfcp_xact_t *xact, void *data)
 static void sess_epc_timeout(ogs_pfcp_xact_t *xact, void *data)
 {
     uint8_t type;
+    smf_sess_t *sess;
 
     ogs_assert(xact);
     type = xact->seq[0].type;
+
+    sess = data;
+    sess->timeout_xact = xact;
 
     switch (type) {
     case OGS_PFCP_SESSION_ESTABLISHMENT_REQUEST_TYPE:


### PR DESCRIPTION
When a PFCP timer fires, it needs to have access to the old xact that was expired in order to lookup the type, associated GTP xact, and send the correct GTP error message.