### PR TITLE
[sgwc][smf] check if session is active before dereferencing

### DIFF
--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -279,7 +279,10 @@ sgwc_sess_t *sgwc_sess_add(sgwc_ue_t *sgwc_ue, char *apn)
                     (long long)ogs_app()->pool.sess);
         return NULL;
     }
+
     memset(sess, 0, sizeof *sess);
+
+    sess->active = true;
 
     ogs_pfcp_pool_init(&sess->pfcp);
 
@@ -401,6 +404,11 @@ int sgwc_sess_remove(sgwc_sess_t *sess)
     ogs_assert(sess);
     sgwc_ue = sess->sgwc_ue;
     ogs_assert(sgwc_ue);
+
+    if (!sess->active) {
+        ogs_error("sgwc_sess_remove double-free");
+    }
+    sess->active = false;
 
     ogs_list_remove(&sgwc_ue->sess_list, sess);
 

--- a/src/sgwc/context.h
+++ b/src/sgwc/context.h
@@ -92,6 +92,9 @@ typedef struct sgwc_sess_s {
     ogs_pfcp_node_t *pfcp_node;
 
     sgwc_ue_t       *sgwc_ue;
+
+    bool active;
+
 } sgwc_sess_t;
 
 typedef struct sgwc_bearer_s {

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -494,7 +494,7 @@ void sgwc_s11_handle_modify_bearer_request(
         }
 
         sess = bearer->sess;
-        ogs_assert(sess);
+        ogs_assert(sess && sess->active);
 
         ogs_list_for_each_entry(&pfcp_xact_list, pfcp_xact, tmpnode) {
             if (sess == pfcp_xact->data) {
@@ -631,7 +631,7 @@ void sgwc_s11_handle_delete_session_request(
 
         if (cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
             sess = sgwc_sess_find_by_ebi(sgwc_ue, req->linked_eps_bearer_id.u8);
-            if (!sess) {
+            if (!sess || !sess->active) {
                 ogs_error("Unknown EPS Bearer [IMSI:%s, EBI:%d]",
                         sgwc_ue->imsi_bcd, req->linked_eps_bearer_id.u8);
                 cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
@@ -671,7 +671,7 @@ void sgwc_s11_handle_delete_session_request(
      * Check ALL Context
      ********************/
     ogs_assert(sgwc_ue);
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
     ogs_assert(sess->gnode);
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
         sgwc_ue->mme_s11_teid, sgwc_ue->sgw_s11_teid);
@@ -744,7 +744,7 @@ void sgwc_s11_handle_create_bearer_response(
 
     ogs_assert(bearer);
     sess = bearer->sess;
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
 
     rv = ogs_gtp_xact_commit(s11_xact);
     ogs_expect(rv == OGS_OK);
@@ -833,7 +833,7 @@ void sgwc_s11_handle_create_bearer_response(
      * Check ALL Context
      ********************/
     ogs_assert(sgwc_ue);
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
     ogs_assert(bearer);
 
     /* Correlate with SGW-S1U-TEID */
@@ -928,7 +928,7 @@ void sgwc_s11_handle_update_bearer_response(
 
     ogs_assert(bearer);
     sess = bearer->sess;
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
 
     rv = ogs_gtp_xact_commit(s11_xact);
     ogs_expect(rv == OGS_OK);
@@ -1007,7 +1007,7 @@ void sgwc_s11_handle_update_bearer_response(
      * Check ALL Context
      ********************/
     ogs_assert(sgwc_ue);
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
 
     ogs_debug("    MME_S11_TEID[%d] SGW_S11_TEID[%d]",
         sgwc_ue->mme_s11_teid, sgwc_ue->sgw_s11_teid);
@@ -1060,7 +1060,7 @@ void sgwc_s11_handle_delete_bearer_response(
 
     ogs_assert(bearer);
     sess = bearer->sess;
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
 
     rv = ogs_gtp_xact_commit(s11_xact);
     ogs_expect(rv == OGS_OK);
@@ -1232,7 +1232,7 @@ void sgwc_s11_handle_downlink_data_notification_ack(
     bearer = s11_xact->data;
     ogs_assert(bearer);
     sess = bearer->sess;
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
 
     rv = ogs_gtp_xact_commit(s11_xact);
     ogs_expect(rv == OGS_OK);
@@ -1531,7 +1531,7 @@ void sgwc_s11_handle_bearer_resource_command(
      ********************/
     ogs_assert(bearer);
     sess = bearer->sess;
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
     ogs_assert(sess->gnode);
     ogs_assert(sgwc_ue);
 

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -100,7 +100,7 @@ void sgwc_s5c_handle_create_session_response(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
@@ -320,7 +320,7 @@ void sgwc_s5c_handle_delete_session_response(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
@@ -433,7 +433,7 @@ void sgwc_s5c_handle_modify_bearer_response(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
@@ -558,7 +558,7 @@ void sgwc_s5c_handle_create_bearer_request(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
@@ -677,7 +677,7 @@ void sgwc_s5c_handle_update_bearer_request(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
@@ -778,7 +778,7 @@ void sgwc_s5c_handle_delete_bearer_request(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {
@@ -925,7 +925,7 @@ void sgwc_s5c_handle_bearer_resource_failure_indication(
     /************************
      * Check Session Context
      ************************/
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -128,7 +128,7 @@ static void sgwc_sxa_handle_session_reestablishment(
         sgwc_sess_t *sess, ogs_pfcp_xact_t *pfcp_xact,
         ogs_pfcp_session_establishment_response_t *pfcp_rsp)
 {
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
     ogs_assert(pfcp_xact);
     ogs_assert(pfcp_rsp);
 
@@ -195,7 +195,7 @@ void sgwc_sxa_handle_session_establishment_response(
 
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_warn("No Context");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
@@ -275,7 +275,7 @@ void sgwc_sxa_handle_session_establishment_response(
         return;
     }
 
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
 
     ogs_debug("    SGW_S5C_TEID[0x%x] PGW_S5C_TEID[0x%x]",
         sess->sgw_s5c_teid, sess->pgw_s5c_teid);
@@ -485,11 +485,11 @@ void sgwc_sxa_handle_session_modification_response(
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
     if (flags & OGS_PFCP_MODIFY_SESSION) {
-        if (!sess) {
+        if (!sess || !sess->active) {
             ogs_warn("No Context");
 
             sess = pfcp_xact->data;
-            ogs_assert(sess);
+            ogs_assert(sess && sess->active);
 
             cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         }
@@ -500,11 +500,11 @@ void sgwc_sxa_handle_session_modification_response(
         bearer = pfcp_xact->data;
         ogs_assert(bearer);
 
-        if (!sess) {
+        if (!sess || !sess->active) {
             ogs_warn("No Context");
 
             sess = bearer->sess;
-            ogs_assert(sess);
+            ogs_assert(sess && sess->active);
 
             cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
         }
@@ -533,7 +533,7 @@ void sgwc_sxa_handle_session_modification_response(
 
         OGS_LIST(pdr_to_create_list);
 
-        ogs_assert(sess);
+        ogs_assert(sess && sess->active);
 
         ogs_list_copy(&pdr_to_create_list, &pfcp_xact->pdr_to_create_list);
 
@@ -1232,7 +1232,7 @@ void sgwc_sxa_handle_session_deletion_response(
 
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_warn("No Context");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
@@ -1307,7 +1307,7 @@ void sgwc_sxa_handle_session_deletion_response(
         return;
     }
 
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
     sgwc_ue = sess->sgwc_ue;
     ogs_assert(sgwc_ue);
 
@@ -1368,7 +1368,7 @@ void sgwc_sxa_handle_session_report_request(
 
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_warn("No Context");
         cause_value = OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
     }
@@ -1385,7 +1385,7 @@ void sgwc_sxa_handle_session_report_request(
         return;
     }
 
-    ogs_assert(sess);
+    ogs_assert(sess && sess->active);
     sgwc_ue = sess->sgwc_ue;
     ogs_assert(sgwc_ue);
 

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1068,6 +1068,7 @@ smf_sess_t *smf_sess_add_by_apn(smf_ue_t *smf_ue, char *apn, uint8_t rat_type)
     ogs_fsm_create(&sess->sm, smf_gsm_state_initial, smf_gsm_state_final);
     ogs_fsm_init(&sess->sm, &e);
 
+    sess->active = true;
     sess->smf_ue = smf_ue;
 
     ogs_list_add(&smf_ue->sess_list, sess);
@@ -1276,6 +1277,7 @@ smf_sess_t *smf_sess_add_by_psi(smf_ue_t *smf_ue, uint8_t psi)
     ogs_fsm_create(&sess->sm, smf_gsm_state_initial, smf_gsm_state_final);
     ogs_fsm_init(&sess->sm, &e);
 
+    sess->active = true;
     sess->smf_ue = smf_ue;
 
     ogs_list_add(&smf_ue->sess_list, sess);
@@ -1552,6 +1554,8 @@ void smf_sess_remove(smf_sess_t *sess)
             sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
 
     ogs_list_remove(&smf_ue->sess_list, sess);
+
+    sess->active = false;
 
     memset(&e, 0, sizeof(e));
     e.sess = sess;

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -1555,6 +1555,9 @@ void smf_sess_remove(smf_sess_t *sess)
 
     ogs_list_remove(&smf_ue->sess_list, sess);
 
+    if (!sess->active) {
+        ogs_error("smf_sess_remove double-free");
+    }
     sess->active = false;
 
     memset(&e, 0, sizeof(e));

--- a/src/smf/context.h
+++ b/src/smf/context.h
@@ -416,6 +416,7 @@ typedef struct smf_sess_s {
     bool teardown_gtp;
     bool pfcp_established;
     ogs_pfcp_xact_t *timeout_xact;
+    bool active;
 
 } smf_sess_t;
 

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -330,7 +330,7 @@ void smf_gn_handle_update_pdp_context_request(
         cause_value = OGS_GTP1_CAUSE_MANDATORY_IE_MISSING;
     }
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_warn("No Context");
         cause_value = OGS_GTP1_CAUSE_NON_EXISTENT;
     }

--- a/src/smf/gsm-sm.c
+++ b/src/smf/gsm-sm.c
@@ -835,6 +835,12 @@ void smf_gsm_state_wait_pfcp_establishment(ogs_fsm_t *s, smf_event_t *e)
         switch(e->timer_id) {
         case SMF_TIMEOUT_PFCP_SER:
             ogs_error("PFCP timeout waiting for Session Establishment Response");
+
+            if (!sess->active) {
+                ogs_error("pfcp timeout: sess is not active");
+                return;
+            }
+
             gtp_xact = (ogs_gtp_xact_t *) sess->timeout_xact->assoc_xact;            
 
             switch (gtp_xact->gtp_version) {
@@ -1505,6 +1511,12 @@ void smf_gsm_state_wait_pfcp_deletion(ogs_fsm_t *s, smf_event_t *e)
         switch(e->timer_id) {
         case SMF_TIMEOUT_PFCP_SDR:
             ogs_error("PFCP timeout waiting for Session Deletion Response");
+
+            if (!sess->active) {
+                ogs_error("pfcp timeout: sess is not active");
+                return;
+            }
+
             gtp_xact = (ogs_gtp_xact_t *) sess->timeout_xact->assoc_xact;
 
             switch (gtp_xact->gtp_version) {

--- a/src/smf/n4-handler.c
+++ b/src/smf/n4-handler.c
@@ -281,7 +281,7 @@ void smf_5gc_n4_handle_session_modification_response(
 
     status = OGS_SBI_HTTP_STATUS_OK;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_warn("No Context");
         status = OGS_SBI_HTTP_STATUS_NOT_FOUND;
     }
@@ -833,7 +833,7 @@ void smf_epc_n4_handle_session_modification_response(
 
     ogs_pfcp_xact_commit(xact);
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context");
         return;
     }
@@ -1129,7 +1129,7 @@ void smf_n4_handle_session_report_request(
 
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_warn("No Context");
         cause_value = OGS_PFCP_CAUSE_SESSION_CONTEXT_NOT_FOUND;
     }

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -235,7 +235,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
         case OGS_PFCP_SESSION_ESTABLISHMENT_RESPONSE_TYPE:
             if (!message->h.seid_presence)
                 ogs_error("No SEID");
-            if (!sess) {
+            if (!sess || !sess->active) {
                 ogs_gtp_xact_t *gtp_xact = xact->assoc_xact;
                 ogs_assert(gtp_xact);
                 if (gtp_xact->gtp_version == 1)
@@ -272,7 +272,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                 break;
             }
 
-            if (!sess) {
+            if (!sess || !sess->active) {
                 ogs_pkbuf_t *pkbuf = xact->seq[0].pkbuf;
                 ogs_pfcp_header_t *sent_hdr = (ogs_pfcp_header_t *) pkbuf->data;
                 if (sent_hdr->seid_presence && sent_hdr->seid != 0)
@@ -281,7 +281,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
                     e->sess = sess;
             }
 
-            if (!sess) {
+            if (!sess || !sess->active) {
                 ogs_warn("No session associated with Session Deletion Response");
                 break;
             }

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -443,7 +443,7 @@ void smf_s5c_handle_modify_bearer_request(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
@@ -620,7 +620,7 @@ void smf_s5c_handle_create_bearer_response(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
@@ -797,7 +797,7 @@ void smf_s5c_handle_update_bearer_response(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
@@ -1126,7 +1126,7 @@ void smf_s5c_handle_bearer_resource_command(
      ************************/
     cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
 
-    if (!sess) {
+    if (!sess || !sess->active) {
         ogs_error("No Context");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     } else {


### PR DESCRIPTION
sgwc_sess_t and smf_sess_t pointers are stored for a message, and run the risk of being stale/freed by the time a response is received or timeout occurs. we use an "active" bit to indicate if the session is still valid or was previously cleared by {sgwc|smf}_sess_remove.