### PR TITLE
[smf][sgwc] fix upf/sgwc assignment when no_pfcp_rr_select: true

### DIFF
--- a/src/sgwc/context.c
+++ b/src/sgwc/context.c
@@ -370,8 +370,9 @@ static ogs_pfcp_node_t *selected_sgwu_node(
         }
     }
 
+    // If we get here, it means no suitable UPF can be found
     ogs_error("No SGWUs are PFCP associated that are suited to RR");
-    return ogs_list_first(&ogs_pfcp_self()->pfcp_peer_list);
+    return NULL;
 }
 
 void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
@@ -391,6 +392,11 @@ void sgwc_sess_select_sgwu(sgwc_sess_t *sess)
     /* setup GTP session with selected SGW-U */
     ogs_pfcp_self()->pfcp_node =
         selected_sgwu_node(ogs_pfcp_self()->pfcp_node, sess);
+
+    if (ogs_pfcp_self()->pfcp_node == NULL) {
+        return;
+    }
+
     ogs_assert(ogs_pfcp_self()->pfcp_node);
     OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
     ogs_debug("UE using SGW-U on IP[%s]",

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -298,8 +298,7 @@ void sgwc_s11_handle_create_session_request(
     sgwc_sess_select_sgwu(sess);
 
     /* Check if selected SGW-U is associated with SGW-C */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, sgwc_pfcp_state_associated)) {
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -976,6 +976,7 @@ static ogs_pfcp_node_t *selected_upf_node(
             compare_ue_info(node, sess) == true) return node;
     }
 
+    // RR means we now just choose the next associated PFCP
     if (ogs_app()->parameter.no_pfcp_rr_select == 0) {
         /* continue search from current position */
         next = ogs_list_next(current);
@@ -991,8 +992,9 @@ static ogs_pfcp_node_t *selected_upf_node(
         }
     }
 
+    // If we get here, it means no suitable UPF can be found
     ogs_error("No UPFs are PFCP associated that are suited to RR");
-    return ogs_list_first(&ogs_pfcp_self()->pfcp_peer_list);
+    return NULL;
 }
 
 void smf_sess_select_upf(smf_sess_t *sess)
@@ -1012,6 +1014,11 @@ void smf_sess_select_upf(smf_sess_t *sess)
     /* setup GTP session with selected UPF */
     ogs_pfcp_self()->pfcp_node =
         selected_upf_node(ogs_pfcp_self()->pfcp_node, sess);
+
+    if (ogs_pfcp_self()->pfcp_node == NULL) {
+        return;
+    }
+
     ogs_assert(ogs_pfcp_self()->pfcp_node);
     OGS_SETUP_PFCP_NODE(sess, ogs_pfcp_self()->pfcp_node);
     ogs_debug("UE using UPF on IP[%s]",

--- a/src/smf/context.c
+++ b/src/smf/context.c
@@ -976,7 +976,6 @@ static ogs_pfcp_node_t *selected_upf_node(
             compare_ue_info(node, sess) == true) return node;
     }
 
-    // RR means we now just choose the next associated PFCP
     if (ogs_app()->parameter.no_pfcp_rr_select == 0) {
         /* continue search from current position */
         next = ogs_list_next(current);

--- a/src/smf/gn-handler.c
+++ b/src/smf/gn-handler.c
@@ -258,10 +258,9 @@ uint8_t smf_gn_handle_create_pdp_context_request(
     smf_sess_select_upf(sess);
 
     /* Check if selected PGW is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
         return OGS_GTP1_CAUSE_NO_RESOURCES_AVAILABLE;
-
+    
     if ((pfcp_cause = smf_sess_set_ue_ip(sess)) != OGS_PFCP_CAUSE_REQUEST_ACCEPTED) {
         cause_value = gtp_cause_from_pfcp(pfcp_cause, 1);
         return cause_value;

--- a/src/smf/npcf-handler.c
+++ b/src/smf/npcf-handler.c
@@ -445,8 +445,7 @@ bool smf_npcf_smpolicycontrol_handle_create(
     smf_sess_select_upf(sess);
 
     /* Check if selected UPF is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated)) {
         ogs_error("[%s] No associated UPF", smf_ue->supi);
         return false;
     }

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -245,8 +245,7 @@ uint8_t smf_s5c_handle_create_session_request(
     smf_sess_select_upf(sess);
 
     /* Check if selected PGW is associated with SMF */
-    ogs_assert(sess->pfcp_node);
-    if (!OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
+    if (!sess->pfcp_node || !OGS_FSM_CHECK(&sess->pfcp_node->sm, smf_pfcp_state_associated))
         return OGS_GTP2_CAUSE_REMOTE_PEER_NOT_RESPONDING;
 
     /* UE IP Address */


### PR DESCRIPTION
As currently written, if the no_pfcp_rr_select option is set to true and there are no suitable SGWC or UPF for a given UE, the code will simply return the first UPS node regardless of whether it's even attached or not, which could cause some obscure issues later. Correct/expected behavior in this context is to reject the UE.