### PR TITLE
[sgwc] minor transaction context error-handling

### DIFF
--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -90,10 +90,14 @@ void sgwc_s5c_handle_create_session_response(
      ********************/
     ogs_assert(s5c_xact);
     s11_xact = s5c_xact->assoc_xact;
-    ogs_assert(s11_xact);
 
     rv = ogs_gtp_xact_commit(s5c_xact);
     ogs_expect(rv == OGS_OK);
+
+    if (!s11_xact) {
+        ogs_error("No associated s11_xact!");
+        return;
+    }
 
     /************************
      * Check Session Context

--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -180,9 +180,14 @@ void sgwc_sxa_handle_session_establishment_response(
         return sgwc_sxa_handle_session_reestablishment(sess, pfcp_xact, pfcp_rsp);
     }
 
+    if (!recv_message) {
+        ogs_error("recv_message is nil! Aborting...");
+        ogs_pfcp_xact_commit(pfcp_xact);
+        return;
+    }
+
     ogs_assert(pfcp_xact);
     ogs_assert(pfcp_rsp);
-
     ogs_assert(recv_message);
 
     create_session_request = &recv_message->create_session_request;


### PR DESCRIPTION
A couple of sgwc assertions sometimes fail if a message has timed-out while waiting for a response. Instead of asserting/panicking we should check context and handle gracefully (logging an error, cleaning up context, and returning).