### PR TITLE
[mme] turn various asserts into checks with error-handling

### DIFF
--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -112,8 +112,6 @@ void mme_s11_handle_create_session_response(
     ogs_assert(sess);
     mme_ue = sess->mme_ue;
     ogs_assert(mme_ue);
-    source_ue = sgw_ue_cycle(mme_ue->sgw_ue);
-    ogs_assert(source_ue);
 
     if (create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST) {
         target_ue = sgw_ue_cycle(source_ue->target_ue);
@@ -134,6 +132,12 @@ void mme_s11_handle_create_session_response(
     if (!mme_ue_from_teid) {
         ogs_error("No Context in TEID");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
+    }
+
+    source_ue = sgw_ue_cycle(mme_ue->sgw_ue);
+    if (!source_ue) {
+        ogs_error("Cannot find source_ue context");
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;        
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -113,14 +113,6 @@ void mme_s11_handle_create_session_response(
     mme_ue = sess->mme_ue;
     ogs_assert(mme_ue);
 
-    if (create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST) {
-        target_ue = sgw_ue_cycle(source_ue->target_ue);
-        ogs_assert(target_ue);
-    } else {
-        target_ue = source_ue;
-        ogs_assert(target_ue);
-    }
-
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect_or_return(rv == OGS_OK);
 
@@ -138,6 +130,17 @@ void mme_s11_handle_create_session_response(
     if (!source_ue) {
         ogs_error("Cannot find source_ue context");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;        
+    }
+
+    if (create_action == OGS_GTP_CREATE_IN_PATH_SWITCH_REQUEST) {
+        // if source_ue == null we'll catch below
+        if (source_ue) {
+            target_ue = sgw_ue_cycle(source_ue->target_ue);
+            ogs_assert(target_ue);            
+        }
+    } else {
+        target_ue = source_ue;
+        // if source_ue == null we'll catch below
     }
 
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {

--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -444,8 +444,6 @@ void mme_s11_handle_modify_bearer_response(
     modify_action = xact->modify_action;
     mme_ue = xact->data;
     ogs_assert(mme_ue);
-    sgw_ue = sgw_ue_cycle(mme_ue->sgw_ue);
-    ogs_assert(sgw_ue);
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect_or_return(rv == OGS_OK);
@@ -457,6 +455,12 @@ void mme_s11_handle_modify_bearer_response(
 
     if (!mme_ue_from_teid) {
         ogs_error("No Context in TEID");
+        cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
+    }
+
+    sgw_ue = sgw_ue_cycle(mme_ue->sgw_ue);
+    if (!sgw_ue) {
+        ogs_error("Cannot find sgw_ue context");
         cause_value = OGS_GTP2_CAUSE_CONTEXT_NOT_FOUND;
     }
 
@@ -1123,8 +1127,6 @@ void mme_s11_handle_release_access_bearers_response(
     ogs_assert(action);
     mme_ue = xact->data;
     ogs_assert(mme_ue);
-    sgw_ue = sgw_ue_cycle(mme_ue->sgw_ue);
-    ogs_assert(sgw_ue);
 
     rv = ogs_gtp_xact_commit(xact);
     ogs_expect_or_return(rv == OGS_OK);
@@ -1134,6 +1136,15 @@ void mme_s11_handle_release_access_bearers_response(
      ***********************/
     if (!mme_ue_from_teid) {
         ogs_error("No Context in TEID");
+        mme_send_delete_session_or_mme_ue_context_release(mme_ue);
+        return;        
+    }
+
+    sgw_ue = sgw_ue_cycle(mme_ue->sgw_ue);
+    if (!sgw_ue) {
+        ogs_error("Cannot find sgw_ue");
+        mme_send_delete_session_or_mme_ue_context_release(mme_ue);
+        return;        
     }
 
     /********************

--- a/src/mme/nas-path.c
+++ b/src/mme/nas-path.c
@@ -131,6 +131,7 @@ int nas_eps_send_attach_reject(mme_ue_t *mme_ue,
     ogs_nas_emm_cause_t emm_cause, ogs_nas_esm_cause_t esm_cause)
 {
     int rv;
+    enb_ue_t *enb_ue = NULL;
     mme_sess_t *sess = NULL;
     ogs_pkbuf_t *esmbuf = NULL, *emmbuf = NULL;
 
@@ -138,6 +139,12 @@ int nas_eps_send_attach_reject(mme_ue_t *mme_ue,
 
     ogs_debug("[%s] Attach reject", mme_ue->imsi_bcd);
     ogs_debug("    Cause[%d]", emm_cause);
+
+    enb_ue = enb_ue_cycle(mme_ue->enb_ue);
+    if (!enb_ue) {
+        ogs_error("S1 context has already been removed");
+        return OGS_OK;
+    }
 
     sess = mme_sess_first(mme_ue);
     if (sess) {


### PR DESCRIPTION
Similar fixes as the prior commit to sgwc and smf. Key contributions are (1) not segfaulting out on failed assert()s and (2) proper error-handling (tearing down sessions, error messages when appropriate, etc).