### PR TITLE
[core] allow for multiple FSM state transitions

### DIFF
--- a/lib/core/ogs-fsm.c
+++ b/lib/core/ogs-fsm.c
@@ -61,13 +61,16 @@ void ogs_fsm_dispatch(void *sm, void *event)
     if (e)
         (*tmp)(s, e);
 
-    if (s->state != tmp) {
+    while (s->state && s->state != tmp) {
         if (e) {
             e->id = OGS_FSM_EXIT_SIG;
             (*tmp)(s, e);
         } else {
             (*tmp)(s, &exit_event);
         }
+
+        tmp = s->state;
+
         if (e) {
             e->id = OGS_FSM_ENTRY_SIG;
             (*s->state)(s, e);


### PR DESCRIPTION
As currently written, state-machine code allows only one state-transition (e.g. from x_state_initial -> x_state_operational) per event. If code at the destination state itself triggers a state transition (e.g. x_state_initial -> x_state_operational -> x_state_exception), the state will be reflected in subsequent calls, but the entry/exit events (e.g. OGS_FSM_EXIT_SIG at x_state_operational and OGS_FSM_ENTRY_SIG x_state_exception) will never get called.

Fix is straightforward; just change a one-off if() check into a while() loop that runs as long as the new state is not the same as the old state.