### PR TITLE
[mme][sgwc][smf] reorder sanity-checking

### DIFF
--- a/src/mme/mme-s11-handler.c
+++ b/src/mme/mme-s11-handler.c
@@ -146,6 +146,45 @@ void mme_s11_handle_create_session_response(
         return;
     }
 
+    /*********************
+     * Check Cause Value
+     *********************/
+    if (rsp->cause.presence == 0) {
+        ogs_error("No Cause");
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
+    }
+
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+        if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST) {
+            ogs_error("[%s] Attach reject", mme_ue->imsi_bcd);
+            ogs_assert(OGS_OK == nas_eps_send_attach_reject(mme_ue,
+                    EMM_CAUSE_NETWORK_FAILURE, ESM_CAUSE_NETWORK_FAILURE));
+        }
+        mme_send_delete_session_or_mme_ue_context_release(mme_ue);
+        return;
+    }
+
+    cause = rsp->cause.data;
+    ogs_assert(cause);
+    cause_value = cause->value;
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED &&
+        cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED_PARTIALLY &&
+        cause_value !=
+            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE &&
+        cause_value !=
+            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY) {
+        ogs_error("GTP Failed [CAUSE:%d]", cause_value);
+        if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST) {
+            ogs_error("[%s] Attach reject", mme_ue->imsi_bcd);
+            ogs_assert(OGS_OK == nas_eps_send_attach_reject(mme_ue,
+                    EMM_CAUSE_NETWORK_FAILURE, ESM_CAUSE_NETWORK_FAILURE));
+        }
+        mme_send_delete_session_or_mme_ue_context_release(mme_ue);
+        return;
+    }
+
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
+
     /*****************************************
      * Check Mandatory/Conditional IE Missing
      *****************************************/
@@ -191,11 +230,6 @@ void mme_s11_handle_create_session_response(
         }
     }
 
-    if (rsp->cause.presence == 0) {
-        ogs_error("No Cause");
-        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
-    }
-
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST) {
             ogs_error("[%s] Attach reject", mme_ue->imsi_bcd);
@@ -207,7 +241,7 @@ void mme_s11_handle_create_session_response(
     }
 
     /********************
-     * Check Cause Value
+     * Re-Examine Cause Value(s)
      ********************/
     ogs_assert(cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED);
 
@@ -229,25 +263,6 @@ void mme_s11_handle_create_session_response(
             mme_send_delete_session_or_mme_ue_context_release(mme_ue);
             return;
         }
-    }
-
-    cause = rsp->cause.data;
-    ogs_assert(cause);
-    cause_value = cause->value;
-    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED &&
-        cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED_PARTIALLY &&
-        cause_value !=
-            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE &&
-        cause_value !=
-            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY) {
-        ogs_error("GTP Failed [CAUSE:%d]", cause_value);
-        if (create_action == OGS_GTP_CREATE_IN_ATTACH_REQUEST) {
-            ogs_error("[%s] Attach reject", mme_ue->imsi_bcd);
-            ogs_assert(OGS_OK == nas_eps_send_attach_reject(mme_ue,
-                    EMM_CAUSE_NETWORK_FAILURE, ESM_CAUSE_NETWORK_FAILURE));
-        }
-        mme_send_delete_session_or_mme_ue_context_release(mme_ue);
-        return;
     }
 
     /********************

--- a/src/sgwc/s11-handler.c
+++ b/src/sgwc/s11-handler.c
@@ -179,6 +179,24 @@ void sgwc_s11_handle_create_session_request(
         return;
     }
 
+    // sender TEID must be VERY FIRST THING we check/set so that any 
+    // sent error-messages have the correct TEID for handling at mme
+    if (req->sender_f_teid_for_control_plane.presence == 0) {
+        ogs_error("No Sender F-TEID");
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
+    }
+
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
+        ogs_gtp_send_error_message(
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+        return;
+    }
+
+    mme_s11_teid = req->sender_f_teid_for_control_plane.data;
+    ogs_assert(mme_s11_teid);
+    sgwc_ue->mme_s11_teid = be32toh(mme_s11_teid->teid);
+
     /*****************************************
      * Check Mandatory/Conditional IE Missing
      *****************************************/
@@ -202,10 +220,6 @@ void sgwc_s11_handle_create_session_request(
     }
     if (req->access_point_name.presence == 0) {
         ogs_error("No APN");
-        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
-    }
-    if (req->sender_f_teid_for_control_plane.presence == 0) {
-        ogs_error("No Sender F-TEID");
         cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
     }
     if (req->pgw_s5_s8_address_for_control_plane_or_pmip.presence == 0) {

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -172,11 +172,6 @@ void sgwc_s5c_handle_create_session_response(
         cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
     }
 
-    if (rsp->cause.presence == 0) {
-        ogs_error("No Cause");
-        cause_value = OGS_GTP2_CAUSE_CONDITIONAL_IE_MISSING;
-    }
-
     if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED) {
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -115,6 +115,38 @@ void sgwc_s5c_handle_create_session_response(
         return;
     }
 
+    /*********************
+     * Check Cause Value
+     *********************/
+    if (rsp->cause.presence == 0) {
+        ogs_error("No Cause");
+        cause_value = OGS_GTP2_CAUSE_MANDATORY_IE_MISSING;
+        ogs_gtp_send_error_message(
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+        ogs_assert(OGS_OK == sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL));
+        return;
+    }
+
+    cause = rsp->cause.data;
+    ogs_assert(cause);
+    cause_value = cause->value;
+    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED &&
+        cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED_PARTIALLY &&
+        cause_value !=
+            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE &&
+        cause_value !=
+            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY) {
+        ogs_error("GTP Failed [CAUSE:%d]", cause_value);
+        ogs_gtp_send_error_message(
+                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
+                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+        ogs_assert(OGS_OK == sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL));
+        return;
+    }
+
+    cause_value = OGS_GTP2_CAUSE_REQUEST_ACCEPTED;
+
     /*****************************************
      * Check Mandatory/Conditional IE Missing
      *****************************************/
@@ -153,7 +185,7 @@ void sgwc_s5c_handle_create_session_response(
     }
 
     /********************
-     * Check Cause Value
+     * Re-Examine Cause Value(s)
      ********************/
     ogs_assert(cause_value == OGS_GTP2_CAUSE_REQUEST_ACCEPTED);
 
@@ -172,22 +204,6 @@ void sgwc_s5c_handle_create_session_response(
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
             return;
         }
-    }
-
-    cause = rsp->cause.data;
-    ogs_assert(cause);
-    cause_value = cause->value;
-    if (cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED &&
-        cause_value != OGS_GTP2_CAUSE_REQUEST_ACCEPTED_PARTIALLY &&
-        cause_value !=
-            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_NETWORK_PREFERENCE &&
-        cause_value !=
-            OGS_GTP2_CAUSE_NEW_PDN_TYPE_DUE_TO_SINGLE_ADDRESS_BEARER_ONLY) {
-        ogs_error("GTP Failed [CAUSE:%d]", cause_value);
-        ogs_gtp_send_error_message(
-                s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
-                OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
-        return;
     }
 
     /********************

--- a/src/smf/s5c-handler.c
+++ b/src/smf/s5c-handler.c
@@ -268,13 +268,6 @@ uint8_t smf_s5c_handle_create_session_request(
         sess->ipv4 ? OGS_INET_NTOP(&sess->ipv4->addr, buf1) : "",
         sess->ipv6 ? OGS_INET6_NTOP(&sess->ipv6->addr, buf2) : "");
 
-    /* Control Plane(DL) : SGW-S5C */
-    sgw_s5c_teid = req->sender_f_teid_for_control_plane.data;
-    ogs_assert(sgw_s5c_teid);
-    sess->sgw_s5c_teid = be32toh(sgw_s5c_teid->teid);
-    rv = ogs_gtp2_f_teid_to_ip(sgw_s5c_teid, &sess->sgw_s5c_ip);
-    ogs_assert(rv == OGS_OK);
-
     ogs_debug("    SGW_S5C_TEID[0x%x] SMF_N4_TEID[0x%x]",
             sess->sgw_s5c_teid, sess->smf_n4_teid);
 


### PR DESCRIPTION
For full 3GPP compliance, message sanity checks need to be performed in a certain order. For example, the sender's TEID must be sanity-checked very early so that (a) we error out (with TEID=0) if it is invalid or (b) the error-messages generated from any subsequent sanity-checks have the correct TEID value filled in.