### PR TITLE
[sgwc] teardown sess if delete_session_request not accepted

### DIFF
--- a/src/sgwc/sxa-handler.c
+++ b/src/sgwc/sxa-handler.c
@@ -1319,6 +1319,9 @@ void sgwc_sxa_handle_session_deletion_response(
             ogs_gtp_send_error_message(
                     gtp_xact, teid, gtp_message->h.type, cause_value);
         }
+        if (sess) {
+            sgwc_sess_remove(sess);
+        }
         return;
     }
 


### PR DESCRIPTION
This codepath occurs when the sgwc sends a delete_session_request message to the sgwu and receives a delete_session_response indicating failure. Currently, the sgwc simply logs an error and sends a gtp error message back to the mme, and essentially leaves the sgwc session context intact. I believe the correct behavior in this context is to also delete/remove the sgwc session. Note that the PFCP delete_session operation is idempotent (i.e. the sgwu will return a successful response even if the session does not exist) so this context should occur quite infrequently.