### PR TITLE
[sgwc] teardown pfcp if s5 errors out

### DIFF
--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -142,6 +142,7 @@ void sgwc_s5c_handle_create_session_response(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         ogs_assert(OGS_OK == sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL));
+        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
 
@@ -155,6 +156,7 @@ void sgwc_s5c_handle_create_session_response(
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, session_cause);
+        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
 
@@ -188,6 +190,7 @@ void sgwc_s5c_handle_create_session_response(
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
+        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
     
@@ -213,6 +216,7 @@ void sgwc_s5c_handle_create_session_response(
             ogs_gtp_send_error_message(
                     s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, bearer_cause);
+            sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
             return;
         }
     }
@@ -249,6 +253,7 @@ void sgwc_s5c_handle_create_session_response(
                     s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                     OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
+            sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
             return;
         }
 
@@ -269,6 +274,7 @@ void sgwc_s5c_handle_create_session_response(
                     s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE,
                     OGS_GTP2_CAUSE_MANDATORY_IE_MISSING);
+            sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
             return;
         }
 
@@ -397,6 +403,7 @@ void sgwc_s5c_handle_modify_bearer_response(
             ogs_gtp_send_error_message(
                     s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, cause_value);
+        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
 
@@ -415,6 +422,7 @@ void sgwc_s5c_handle_modify_bearer_response(
             ogs_gtp_send_error_message(
                     s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                     OGS_GTP2_MODIFY_BEARER_RESPONSE_TYPE, session_cause);
+        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
 
@@ -512,6 +520,7 @@ void sgwc_s5c_handle_delete_session_response(
         ogs_gtp_send_error_message(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_DELETE_SESSION_RESPONSE_TYPE, cause_value);
+        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
 

--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -142,7 +142,6 @@ void sgwc_s5c_handle_create_session_response(
                 s11_xact, sgwc_ue ? sgwc_ue->mme_s11_teid : 0,
                 OGS_GTP2_CREATE_SESSION_RESPONSE_TYPE, cause_value);
         ogs_assert(OGS_OK == sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL));
-        sgwc_pfcp_send_session_deletion_request(sess, NULL, NULL);
         return;
     }
 


### PR DESCRIPTION
Currently, if the sgwc receives an error message from the smf over the s5 interface (responsible for GTPv2 session establishment/teardown) it *does* send the error back to the mme, but does *not* teardown its own session (or the previously created PFCP session at the sgwu). This code handles that by sending PFCP session deletion request messages in response to these errors. This ensures that the sgwu tears-down the session, and also ensures that the sgwc tears-down the session as well, either (a) upon subsequent receipt of a response from the sgwu or (b) on timeout.