### PR TITLE
[tests] increase registration timeout to 45sec

### DIFF
--- a/tests/registration/meson.build
+++ b/tests/registration/meson.build
@@ -40,4 +40,5 @@ test5gc_registration_exe = executable('registration',
 test('registration',
     test5gc_registration_exe,
     is_parallel : false,
-    suite: '5gc')
+    suite: '5gc',
+    timeout: 45)


### PR DESCRIPTION
I've noticed that sometimes (it is unclear exactly why/when) the Ubuntu testing suite fails with a TIMEOUT on the registration test. This has been a hard problem to understand/debug because my home environments are naturally different than GitHub's testing suite environment, but I've noticed anecdotally that even under the best conditions at home, the registration test takes 22sec, which is substantially longer than any of the other tests.

I suspect that the GitHub CI environment does not make hard guarantees about the resources allocated for testing, and as a result we will sometimes see TIMEOUT failures when insufficient compute resources are provisioned for the test. I am increasing the TIMEOUT value from the default (30sec) to 45sec for the registration test only, on the hunch that this might fix the problem. Will keep a close eye on this and continue to investigate.