### PR TITLE
[tests] change github runner to self-hosted

### DIFF
--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
     - name: Create the TUN device with the interface name `ogstun`.
       run: |
+          sudo ip tuntap del ogstun mode tun
           sudo ip tuntap add name ogstun mode tun
           sudo ip addr add 10.45.0.1/16 dev ogstun
           sudo ip addr add 2001:db8:cafe::1/48 dev ogstun

--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install the dependencies for building the source code.
       run: |
           sudo apt update
-          sudo apt install python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson
+          sudo apt install -y python3-pip python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson
     - name: Check out repository code
       uses: actions/checkout@main
     - name: Setup Meson Build

--- a/.github/workflows/meson-ci.yml
+++ b/.github/workflows/meson-ci.yml
@@ -49,7 +49,7 @@ jobs:
 #
   ubuntu-latest:
     name: Build and Test on Ubuntu Latest
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     services:
       mongodb:
         image: mongo


### PR DESCRIPTION
For some still-unknown reason the GitHub CI tests sometimes/sporadically fail with GitHub hosted runners. My hunch is that this has to do with constrained/non-guaranteed virtual resources. Self-hosting on our own digital ocean droplet appears to have resolved this issue.