### PR TITLE
[pfcp] sendto should always return OGS_OK

### DIFF
--- a/lib/pfcp/path.c
+++ b/lib/pfcp/path.c
@@ -122,7 +122,6 @@ int ogs_pfcp_sendto(ogs_pfcp_node_t *node, ogs_pkbuf_t *pkbuf)
                     sock->fd, pkbuf->data, pkbuf->len,
                     OGS_ADDR(addr, buf), OGS_PORT(addr));
         }
-        return OGS_ERROR;
     }
 
     return OGS_OK;


### PR DESCRIPTION
sendto() was crashing the entire SMF when it received an EDESTADDRREQ error. True source of the error is unknown (maybe wireguard hiccupping? looks like the packet was sent out on the wrong wg tunnel) but regardless of the error we should actually just handle gracefully, log error, and move on. PFCP already has its own retrans/recovery mechanisms so loss here is irrelevant.