### PR TITLE
remove already_associated variable

### DIFF
--- a/lib/pfcp/context.h
+++ b/lib/pfcp/context.h
@@ -112,8 +112,6 @@ typedef struct ogs_pfcp_node_s {
 
     ogs_pfcp_up_function_features_t up_function_features;
     int up_function_features_len;
-
-    bool already_associated;
 } ogs_pfcp_node_t;
 
 typedef enum {

--- a/src/sgwc/pfcp-sm.c
+++ b/src/sgwc/pfcp-sm.c
@@ -175,10 +175,7 @@ void sgwc_pfcp_state_associated(ogs_fsm_t *s, sgwc_event_t *e)
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
 
-        if (node->already_associated) {
-            sgwc_pfcp_resend_established_sessions(node);
-        }
-        node->already_associated = true;
+        sgwc_pfcp_resend_established_sessions(node);
 
         stats_update_sgwc_pfcp_nodes();
 

--- a/src/smf/pfcp-sm.c
+++ b/src/smf/pfcp-sm.c
@@ -177,10 +177,7 @@ void smf_pfcp_state_associated(ogs_fsm_t *s, smf_event_t *e)
         ogs_timer_start(node->t_no_heartbeat,
                 ogs_app()->time.message.pfcp.no_heartbeat_duration);
 
-        if (node->already_associated) {
-            smf_epc_pfcp_resend_established_sessions(node);
-        }
-        node->already_associated = true;
+        smf_epc_pfcp_resend_established_sessions(node);
 
         stats_update_smf_pfcp_nodes();
 


### PR DESCRIPTION
The already_associated variable was used to reduce chatter, in that the first time the CPS associates with a UPS, it will not ask it to delete all sessions. HOWEVER this did not take into account the situation wherein the CPS crashes and re-associates with a UPS, in which case the CPS thinks it's the first association but the UPS still has some "ghost" sessions that can linger and cause signaling issues. Thus we need to always send the reset message when we join just to make sure we're working with a clean slate.