### PR TITLE
removing cdefs.h so we can compile with musl

### DIFF
--- a/lib/ipfw/expand_number.c
+++ b/lib/ipfw/expand_number.c
@@ -25,7 +25,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/lib/libutil/expand_number.c 211343 2010-08-15 18:32:06Z des $");
 
 #include <sys/types.h>

--- a/lib/ipfw/humanize_number.c
+++ b/lib/ipfw/humanize_number.c
@@ -30,7 +30,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/lib/libutil/humanize_number.c 220582 2011-04-12 22:48:03Z delphij $");
 
 #include <sys/types.h>

--- a/lib/ipfw/missing.h
+++ b/lib/ipfw/missing.h
@@ -59,7 +59,6 @@ void panic(const char *fmt, ...);
 #include <stdlib.h>	// bsearch
 #ifdef NEED_KERNEL
 #define _KERNEL
-#include <sys/cdefs.h>
 #include <sys/param.h>
 
 #define __user	// not defined here ?


### PR DESCRIPTION
<sys/cdefs.h> is not included with musl, which we use to compile for smaller embedded architectures. More importantly, its use is also deprecated and should be removed regardless. Additionally, best I can tell, cdefs.h is included in these three files but never used, and compilation succeeds just fine without it.