### PR TITLE
[sgwc] s11_xact checked unnecessarily

### DIFF
--- a/src/sgwc/s5c-handler.c
+++ b/src/sgwc/s5c-handler.c
@@ -485,7 +485,7 @@ void sgwc_s5c_handle_delete_session_response(
      * Check Transaction
      ********************/
     // if we don't have a transaction to delete, move on
-    if (!s5c_xact || !s11_xact) {
+    if (!s5c_xact) {
         ogs_error("Cannot find transaction to delete!");
         return;
     }


### PR DESCRIPTION
Tiny logic bug-fix. This conditional returns if s11_xact is null. However, it is always null at this point since it's dereferenced from s5c_xact below.