### PR TITLE
increase 5gc test startup time

### DIFF
--- a/tests/app/5gc-init.c
+++ b/tests/app/5gc-init.c
@@ -85,7 +85,7 @@ int app_initialize(const char *const argv[])
      * 
      * If freeDiameter is not used, it uses a delay of less than 4 seconds.
      */
-    ogs_msleep(500);
+    ogs_msleep(5000);
 
     return OGS_OK;;
 }


### PR DESCRIPTION
The open5gs testing framework uses a hard-coded wait time before running tests to ensure all components are up and talking to each other. The 5gc value is 500ms but needs to be longer so that Diameter connections come up; 5sec appears to solve this problem consistently.