### PR TITLE
make reject due to DNN mismatch clearer in logs

### DIFF
--- a/src/amf/gmm-handler.c
+++ b/src/amf/gmm-handler.c
@@ -1082,8 +1082,8 @@ int gmm_handle_ul_nas_transport(amf_ue_t *amf_ue,
             }
 
             if (!selected_slice || !sess->dnn) {
-                ogs_warn("[%s] DNN Not Supported OR "
-                            "Not Subscribed in the Slice", amf_ue->supi);
+                ogs_warn("[%s] UE requested DNN \"%s\" Not Supported OR "
+                            "Not Subscribed in the Slice", amf_ue->supi, dnn->value);
                 r = nas_5gs_send_gmm_status(amf_ue,
                         OGS_5GMM_CAUSE_DNN_NOT_SUPPORTED_OR_NOT_SUBSCRIBED_IN_THE_SLICE);
                 ogs_expect(r == OGS_OK);


### PR DESCRIPTION
If the 5G UE asks for a DNN (5g's version of an APN) that we don't support, the amf rejects it with a "DNN Not Supported OR Not Subscribed in the Slice" log message. This is accurate but kinda cryptic. I expanded the error message to indicate the name of the APN the UE is requesting, makes the message more intuitive and helps us debug.